### PR TITLE
Init presubmits (from sigs.k8s.io/release-utils) 

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,168 @@
+---
+run:
+  concurrency: 6
+  deadline: 5m
+issues:
+  exclude-rules:
+    # counterfeiter fakes are usually named 'fake_<something>.go'
+    - path: fake_.*\.go
+      linters:
+        - gocritic
+        - golint
+        - dupl
+linters:
+  disable-all: true
+  enable:
+    - asciicheck
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - dupl
+    - durationcheck
+    - errcheck
+    - goconst
+    - gocritic
+    - gocyclo
+    - godox
+    - gofmt
+    - gofumpt
+    - goheader
+    - goimports
+    - golint
+    - gomoddirectives
+    - gomodguard
+    - goprintffuncname
+    - gosimple
+    - govet
+    - importas
+    - ineffassign
+    - makezero
+    - misspell
+    - nakedret
+    - prealloc
+    - predeclared
+    - promlinter
+    - rowserrcheck
+    - sqlclosecheck
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace
+    # - cyclop
+    # - errorlint
+    # - exhaustive
+    # - exhaustivestruct
+    # - exportloopref
+    # - forbidigo
+    # - forcetypeassert
+    # - funlen
+    # - gci
+    # - gochecknoglobals
+    # - gochecknoinits
+    # - gocognit
+    # - godot
+    # - goerr113
+    # - gomnd
+    # - gosec
+    # - ifshort
+    # - lll
+    # - nestif
+    # - nilerr
+    # - nlreturn
+    # - noctx
+    # - nolintlint
+    # - paralleltest
+    # - revive
+    # - scopelint
+    # - tagliatelle
+    # - testpackage
+    # - thelper
+    # - tparallel
+    # - wastedassign
+    # - wrapcheck
+    # - wsl
+linters-settings:
+  godox:
+    keywords:
+      - BUG
+      - FIXME
+      - HACK
+  errcheck:
+    check-type-assertions: true
+    check-blank: true
+  gocritic:
+    enabled-checks:
+      # Diagnostic
+      - appendAssign
+      - argOrder
+      - badCond
+      - caseOrder
+      - codegenComment
+      - commentedOutCode
+      - deprecatedComment
+      - dupArg
+      - dupBranchBody
+      - dupCase
+      - dupSubExpr
+      - exitAfterDefer
+      - flagDeref
+      - flagName
+      - nilValReturn
+      - offBy1
+      - sloppyReassign
+      - weakCond
+      - octalLiteral
+
+      # Performance
+      - appendCombine
+      - equalFold
+      - hugeParam
+      - indexAlloc
+      - rangeExprCopy
+      - rangeValCopy
+
+      # Style
+      - assignOp
+      - boolExprSimplify
+      - captLocal
+      - commentFormatting
+      - commentedOutImport
+      - defaultCaseOrder
+      - docStub
+      - elseif
+      - emptyFallthrough
+      - emptyStringTest
+      - hexLiteral
+      - ifElseChain
+      - methodExprCall
+      - regexpMust
+      - singleCaseSwitch
+      - sloppyLen
+      - stringXbytes
+      - switchTrue
+      - typeAssertChain
+      - typeSwitchVar
+      - underef
+      - unlabelStmt
+      - unlambda
+      - unslice
+      - valSwap
+      - wrapperFunc
+      - yodaStyleExpr
+
+      # Opinionated
+      - builtinShadow
+      - importShadow
+      - initClause
+      - nestingReduce
+      - paramTypeCombine
+      - ptrToRefParam
+      - typeUnparen
+      - unnamedResult
+      - unnecessaryBlock

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,12 @@ issues:
         - gocritic
         - golint
         - dupl
+
+  # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
+  max-issues-per-linter: 0
+
+  # Maximum count of issues with the same text. Set to 0 to disable. Default is 3.
+  max-same-issues: 0
 linters:
   disable-all: true
   enable:
@@ -29,7 +35,6 @@ linters:
     - gofumpt
     - goheader
     - goimports
-    - golint
     - gomoddirectives
     - gomodguard
     - goprintffuncname
@@ -40,9 +45,11 @@ linters:
     - makezero
     - misspell
     - nakedret
+    - nolintlint
     - prealloc
     - predeclared
     - promlinter
+    - revive
     - rowserrcheck
     - sqlclosecheck
     - staticcheck
@@ -76,9 +83,7 @@ linters:
     # - nilerr
     # - nlreturn
     # - noctx
-    # - nolintlint
     # - paralleltest
-    # - revive
     # - scopelint
     # - tagliatelle
     # - testpackage
@@ -139,7 +144,6 @@ linters-settings:
       - emptyFallthrough
       - emptyStringTest
       - hexLiteral
-      - ifElseChain
       - methodExprCall
       - regexpMust
       - singleCaseSwitch
@@ -155,6 +159,7 @@ linters-settings:
       - valSwap
       - wrapperFunc
       - yodaStyleExpr
+      # - ifElseChain
 
       # Opinionated
       - builtinShadow
@@ -166,3 +171,16 @@ linters-settings:
       - typeUnparen
       - unnamedResult
       - unnecessaryBlock
+  nolintlint:
+    # Enable to ensure that nolint directives are all used. Default is true.
+    allow-unused: false
+    # Disable to ensure that nolint directives don't have a leading space. Default is true.
+    # TODO(lint): Enforce machine-readable `nolint` directives
+    allow-leading-space: true
+    # Exclude following linters from requiring an explanation.  Default is [].
+    allow-no-explanation: []
+    # Enable to require an explanation of nonzero length after each nolint directive. Default is false.
+    # TODO(lint): Enforce explanations for `nolint` directives
+    require-explanation: false
+    # Enable to require nolint directives to mention the specific linter being suppressed. Default is false.
+    require-specific: true

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,0 +1,1 @@
+dependencies:

--- a/gcli/gcli.go
+++ b/gcli/gcli.go
@@ -23,6 +23,7 @@ import (
 )
 
 const (
+	// GCloudExecutable is the name of the Google Cloud SDK executable
 	GCloudExecutable = "gcloud"
 	gsutilExecutable = "gsutil"
 )

--- a/git/git.go
+++ b/git/git.go
@@ -1054,16 +1054,16 @@ func (r *Repo) UserCommit(msg string) error {
 
 // Commit commits the current repository state
 func (r *Repo) Commit(msg string) error {
-	if err := r.CommitWithOptions(msg, &git.CommitOptions{
-		Author: &object.Signature{
-			Name:  defaultGitUser,
-			Email: defaultGitEmail,
-			When:  time.Now(),
+	return r.CommitWithOptions(
+		msg,
+		&git.CommitOptions{
+			Author: &object.Signature{
+				Name:  defaultGitUser,
+				Email: defaultGitEmail,
+				When:  time.Now(),
+			},
 		},
-	}); err != nil {
-		return err
-	}
-	return nil
+	)
 }
 
 // CommitWithOptions commits the current repository state

--- a/git/git.go
+++ b/git/git.go
@@ -360,13 +360,14 @@ func CloneOrOpenRepo(repoPath, repoURL string, useSSH bool) (*Repo, error) {
 		logrus.Debugf("Using existing repository path %q", repoPath)
 		_, err := os.Stat(repoPath)
 
-		if err == nil {
+		switch {
+		case err == nil:
 			// The file or directory exists, just try to update the repo
 			return updateRepo(repoPath)
-		} else if os.IsNotExist(err) {
+		case os.IsNotExist(err):
 			// The directory does not exists, we still have to clone it
 			targetDir = repoPath
-		} else {
+		default:
 			// Something else bad happened
 			return nil, errors.Wrap(err, "unable to update repo")
 		}

--- a/git/git.go
+++ b/git/git.go
@@ -45,12 +45,25 @@ import (
 )
 
 const (
-	DefaultGithubOrg         = "kubernetes"
-	DefaultGithubRepo        = "kubernetes"
+	// DefaultGithubOrg is the default GitHub org used for Kubernetes project
+	// repos
+	DefaultGithubOrg = "kubernetes"
+
+	// DefaultGithubRepo is the default git repository
+	DefaultGithubRepo = "kubernetes"
+
+	// DefaultGithubReleaseRepo is the default git repository used for
+	// SIG Release
 	DefaultGithubReleaseRepo = "sig-release"
-	DefaultRemote            = "origin"
-	DefaultRef               = "HEAD"
-	DefaultBranch            = "master"
+
+	// DefaultRemote is the default git remote name
+	DefaultRemote = "origin"
+
+	// DefaultRef is the default git reference name
+	DefaultRef = "HEAD"
+
+	// DefaultBranch is the default branch name
+	DefaultBranch = "master"
 
 	defaultGithubAuthRoot = "git@github.com:"
 	defaultGitUser        = "Anago GCB"
@@ -246,7 +259,7 @@ func (r *Remote) URLs() []string {
 	return r.urls
 }
 
-// Wrapper type for a Kubernetes repository instance
+// Repo is a wrapper for a Kubernetes repository instance
 type Repo struct {
 	inner      Repository
 	worktree   Worktree
@@ -286,7 +299,7 @@ func (r *Repo) Dir() string {
 	return r.dir
 }
 
-// Set the repo into dry run mode, which does not modify any remote locations
+// SetDry sets the repo to dry-run mode, which does not modify any remote locations
 // at all.
 func (r *Repo) SetDry() {
 	r.dryRun = true
@@ -519,7 +532,7 @@ func (r *Repo) RevParseTagShort(rev string) (string, error) {
 	return fullRev[:10], nil
 }
 
-// RevParseTagShort parses a git revision and returns a SHA1 trimmed to the length
+// RevParseShort parses a git revision and returns a SHA1 trimmed to the length
 // 10 on success, otherwise an error.
 func (r *Repo) RevParseShort(rev string) (string, error) {
 	fullRev, err := r.RevParse(rev)

--- a/github/github.go
+++ b/github/github.go
@@ -73,6 +73,7 @@ func DefaultOptions() *Options {
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 //counterfeiter:generate . Client
+// Client is an interface modeling supported GitHub operations
 type Client interface {
 	GetCommit(
 		context.Context, string, string, string,

--- a/github/record.go
+++ b/github/record.go
@@ -316,11 +316,8 @@ func (c *githubNotesRecordClient) recordAPICall(
 	if err != nil {
 		return err
 	}
-	if err := os.WriteFile(
-		filepath.Join(c.recordDir, fileName), file, os.FileMode(0o644),
-	); err != nil {
-		return err
-	}
 
-	return nil
+	return os.WriteFile(
+		filepath.Join(c.recordDir, fileName), file, os.FileMode(0o644),
+	)
 }

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
+	github.com/carolynvs/magex v0.6.0
 	github.com/go-git/go-git/v5 v5.4.2
 	github.com/google/go-github/v37 v37.0.0
 	github.com/pkg/errors v0.9.1
@@ -26,6 +27,7 @@ require (
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 // indirect
+	github.com/magefile/mage v1.11.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect
@@ -37,4 +39,5 @@ require (
 	google.golang.org/protobuf v1.25.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+	k8s.io/utils v0.0.0-20210305010621-2afb4311ab10 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,7 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/carolynvs/magex v0.6.0 h1:rzz4RnBiR8hr2WYEsmq+mqkRLEstPnEK8ZP9MgxNY9Y=
 github.com/carolynvs/magex v0.6.0/go.mod h1:hqaEkr9TAv+kFb/5wgDiTdszF13rpe0Q+bWHmTe6N74=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
@@ -165,6 +166,7 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/magefile/mage v1.11.0 h1:C/55Ywp9BpgVVclD3lRnSYCwXTYxmSppIgLeDYlNuls=
 github.com/magefile/mage v1.11.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
 github.com/matryer/is v1.2.0 h1:92UTHpy8CDwaJ08GqLDzhhuixiBUUD1p3AU6PHddz4A=
 github.com/matryer/is v1.2.0/go.mod h1:2fLPjFQM9rhQ15aVEtbuwhJinnOqrmgXPNdZsdwlWXA=
@@ -194,6 +196,7 @@ github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNX
 github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -508,6 +511,7 @@ honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
+k8s.io/utils v0.0.0-20210305010621-2afb4311ab10 h1:u5rPykqiCpL+LBfjRkXvnK71gOgIdmq3eHUEkPrbeTI=
 k8s.io/utils v0.0.0-20210305010621-2afb4311ab10/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=

--- a/mage.go
+++ b/mage.go
@@ -1,0 +1,27 @@
+// +build ignore
+
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+
+	"github.com/magefile/mage/mage"
+)
+
+func main() { os.Exit(mage.Main()) }

--- a/magefile.go
+++ b/magefile.go
@@ -1,0 +1,96 @@
+// +build mage
+
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/carolynvs/magex/pkg"
+
+	"sigs.k8s.io/release-utils/mage"
+)
+
+// Default target to run when none is specified
+// If not set, running mage will list available targets
+var Default = Verify
+
+const (
+	binDir    = "bin"
+	scriptDir = "scripts"
+)
+
+var boilerplateDir = filepath.Join(scriptDir, "boilerplate")
+
+// All runs all targets for this repository
+func All() error {
+	if err := Verify(); err != nil {
+		return err
+	}
+
+	if err := Test(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Test runs various test functions
+func Test() error {
+	if err := mage.TestGo(true); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Verify runs repository verification scripts
+func Verify() error {
+	fmt.Println("Ensuring mage is available...")
+	if err := pkg.EnsureMage(""); err != nil {
+		return err
+	}
+
+	fmt.Println("Running copyright header checks...")
+	if err := mage.VerifyBoilerplate("", binDir, boilerplateDir, false); err != nil {
+		return err
+	}
+
+	fmt.Println("Running external dependency checks...")
+	if err := mage.VerifyDeps("", "", "", true); err != nil {
+		return err
+	}
+
+	fmt.Println("Running go module linter...")
+	if err := mage.VerifyGoMod(scriptDir); err != nil {
+		return err
+	}
+
+	fmt.Println("Running golangci-lint...")
+	if err := mage.RunGolangCILint("", false); err != nil {
+		return err
+	}
+
+	fmt.Println("Running go build...")
+	if err := mage.VerifyBuild(scriptDir); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/object/gcs.go
+++ b/object/gcs.go
@@ -241,7 +241,8 @@ func (g *GCS) getPath(
 
 	gcsPathParts = append(gcsPathParts, bucket, gcsRoot)
 
-	if pathType == "release" {
+	switch pathType {
+	case "release":
 		if fast {
 			gcsPathParts = append(gcsPathParts, "fast")
 		}
@@ -249,8 +250,8 @@ func (g *GCS) getPath(
 		if version != "" {
 			gcsPathParts = append(gcsPathParts, version)
 		}
-	} else if pathType == "marker" {
-	} else {
+	case "marker":
+	default:
 		return "", errors.New("a GCS path type must be specified")
 	}
 
@@ -267,15 +268,16 @@ func (g *GCS) NormalizePath(gcsPathParts ...string) (string, error) {
 
 	// Ensure there is at least one element in the gcsPathParts slice before
 	// trying to construct a path
-	if len(gcsPathParts) == 0 {
+	switch len(gcsPathParts) {
+	case 0:
 		return "", errors.New("must contain at least one path part")
-	} else if len(gcsPathParts) == 1 {
+	case 1:
 		if gcsPathParts[0] == "" {
 			return "", errors.New("path should not be an empty string")
 		}
 
 		gcsPath = gcsPathParts[0]
-	} else {
+	default:
 		var emptyParts int
 
 		for i, part := range gcsPathParts {

--- a/object/gcs.go
+++ b/object/gcs.go
@@ -104,7 +104,7 @@ var (
 	noClobberFlag  = "-n"
 )
 
-// CopyToGCS copies a local directory to the specified GCS path
+// CopyToRemote copies a local directory to the specified GCS path
 func (g *GCS) CopyToRemote(src, gcsPath string) error {
 	logrus.Infof("Copying %s to GCS (%s)", src, gcsPath)
 	gcsPath, gcsPathErr := g.NormalizePath(gcsPath)
@@ -259,7 +259,7 @@ func (g *GCS) getPath(
 	return g.NormalizePath(gcsPathParts...)
 }
 
-// NormalizeGCSPath takes a GCS path and ensures that the `GcsPrefix` is
+// NormalizePath takes a GCS path and ensures that the `GcsPrefix` is
 // prepended to it.
 // TODO: Should there be an append function for paths to prevent multiple calls
 //       like in build.checkBuildExists()?

--- a/object/store.go
+++ b/object/store.go
@@ -19,6 +19,7 @@ package object
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 
 //counterfeiter:generate . Store
+// Store is an interface modeling supported filestore operations
 type Store interface {
 	// Configure options
 	SetOptions(opts ...OptFn)

--- a/regex/regex.go
+++ b/regex/regex.go
@@ -24,4 +24,6 @@ const (
 	branchRegexStr = `master|release-([0-9]{1,})\.([0-9]{1,})(\.([0-9]{1,}))*$`
 )
 
+// BranchRegex returns a *regexp.Regexp which evaluates the structure of a
+// Kubernetes release branch
 var BranchRegex = regexp.MustCompile(branchRegexStr)

--- a/scripts/boilerplate/boilerplate.Dockerfile.txt
+++ b/scripts/boilerplate/boilerplate.Dockerfile.txt
@@ -1,0 +1,14 @@
+# Copyright YEAR The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/scripts/boilerplate/boilerplate.Makefile.txt
+++ b/scripts/boilerplate/boilerplate.Makefile.txt
@@ -1,0 +1,14 @@
+# Copyright YEAR The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/scripts/boilerplate/boilerplate.generatego.txt
+++ b/scripts/boilerplate/boilerplate.generatego.txt
@@ -1,0 +1,16 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+

--- a/scripts/boilerplate/boilerplate.go.txt
+++ b/scripts/boilerplate/boilerplate.go.txt
@@ -1,0 +1,16 @@
+/*
+Copyright YEAR The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+

--- a/scripts/boilerplate/boilerplate.py.txt
+++ b/scripts/boilerplate/boilerplate.py.txt
@@ -1,0 +1,14 @@
+# Copyright YEAR The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/scripts/boilerplate/boilerplate.sh.txt
+++ b/scripts/boilerplate/boilerplate.sh.txt
@@ -1,0 +1,14 @@
+# Copyright YEAR The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/scripts/verify-build.sh
+++ b/scripts/verify-build.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+PLATFORMS=(
+    linux/amd64
+    linux/386
+    linux/arm
+    linux/arm64
+    linux/ppc64le
+    linux/s390x
+    windows/amd64
+    windows/386
+    freebsd/amd64
+    darwin/amd64
+)
+
+for PLATFORM in "${PLATFORMS[@]}"; do
+    OS="${PLATFORM%/*}"
+    ARCH=$(basename "$PLATFORM")
+
+    echo "Building project for $PLATFORM"
+    GOARCH="$ARCH" GOOS="$OS" go build ./...
+done


### PR DESCRIPTION
(Follow-up from https://github.com/kubernetes/test-infra/pull/23585 to enable repo presubmits.)

- Init presubmits (from sigs.k8s.io/release-utils)
- generated: Run `go mod tidy`
- lint(gocritic/ifElseChain): rewrite if-else to switch statement
- golangci-lint: Enforce stricter lint settings
- lint(revive/if-return): redundant if ...; err != nil check
  ...just return error instead.
- lint(revive/exported): comment on exported Foo
  ...should be of the form "Foo ..."

Signed-off-by: Stephen Augustus <foo@auggie.dev>