### PR TITLE
Add git.TestLastCommitSha() and test

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -1341,6 +1341,15 @@ func (r *Repo) ShowLastCommit() (logData string, err error) {
 	return logData, nil
 }
 
+// LastCommitSha returns the sha of the last commit in the repository
+func (r *Repo) LastCommitSha() (string, error) {
+	shaval, err := r.runGitCmd("log", "--pretty=format:'%H'", "-n1")
+	if err != nil {
+		return "", errors.Wrap(err, "trying to retrieve the last commit sha")
+	}
+	return shaval, nil
+}
+
 // FetchRemote gets the objects from the specified remote. It returns true as
 // first argument if something has been fetched remotely.
 func (r *Repo) FetchRemote(remoteName string) (bool, error) {


### PR DESCRIPTION
This PR adds a new function to the git package to retrieve
the last commit SHA in the current repository position.

It also adds a test for the new function.

/assign @Verolop @palnabarun @justaugustus 
/cc @kubernetes-sigs/release-engineering 

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>