### PR TITLE
OWNERS: Update to match the current SIG Release roles

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,8 +2,10 @@
 
 approvers:
   - sig-release-leads
+  - release-engineering-approvers
 reviewers:
-  - sig-release-leads
+  - release-engineering-approvers
+  - release-engineering-reviewers
 labels:
   - sig/release
   - area/release-eng

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,7 +2,24 @@
 
 aliases:
   sig-release-leads:
-    - hasheddan # SIG Technical Lead
+    - cpanato # SIG Technical Lead
     - jeremyrickard # SIG Technical Lead
     - justaugustus # SIG Chair
+    - puerco # SIG Technical Lead
     - saschagrunert # SIG Chair
+  release-engineering-approvers:
+    - cpanato # subproject owner / Release Manager
+    - puerco # subproject owner / Release Manager
+    - saschagrunert # subproject owner / Release Manager
+    - justaugustus # subproject owner / Release Manager
+    - Verolop # Release Manager
+    - xmudrii # Release Manager
+  release-engineering-reviewers:
+    - ameukam # Release Manager Associate
+    - jimangel # Release Manager Associate
+    - mkorbi # Release Manager Associate
+    - palnabarun # Release Manager Associate
+    - onlydole # Release Manager Associate
+    - sethmccombs # Release Manager Associate
+    - thejoycekung # Release Manager Associate
+    - wilsonehusin # Release Manager Associate


### PR DESCRIPTION
This PR updates the OWNERS and OWNERS_ALIASES files
to update the approvers and reviewers if the repository
to match other SIG Release repos, namely:

* Updates the sig-release-leads alias to reflect current members
* Adds a release-engineering-approvers group including leads and release managers
* Adds a release-engineering-reviewers group with Release Manager Associates

/assign @justaugustus 

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>