### PR TITLE
github: Detect secondary rate limit

### DIFF
--- a/github/internal/retry.go
+++ b/github/internal/retry.go
@@ -17,6 +17,9 @@ limitations under the License.
 package internal
 
 import (
+	"crypto/rand"
+	"math/big"
+	"strings"
 	"time"
 
 	"github.com/google/go-github/v37/github"
@@ -82,6 +85,20 @@ func GithubErrChecker(maxTries int, sleeper func(time.Duration)) func(error) boo
 			logrus.
 				WithField("err", aerr).
 				Infof("Hit the abuse rate limit on try %d, sleeping for %s", try, waitDuration)
+			sleeper(waitDuration)
+			return true
+		}
+
+		if strings.Contains(err.Error(), "secondary rate limit. Please wait") {
+			rtime, err := rand.Int(rand.Reader, big.NewInt(30))
+			if err != nil {
+				logrus.Error(err)
+				return false
+			}
+			waitDuration := time.Duration(rtime.Int64()*int64(time.Second)) + defaultGithubSleep
+			logrus.
+				WithField("err", err).
+				Infof("Hit the GitHub secondary rate limit on try %d, sleeping for %s", try, waitDuration)
 			sleeper(waitDuration)
 			return true
 		}

--- a/github/internal/retry_test.go
+++ b/github/internal/retry_test.go
@@ -63,6 +63,12 @@ func TestGithubRetryer(t *testing.T) {
 			errs:            []error{&github.AbuseRateLimitError{}},
 			expectedResults: []bool{true},
 		},
+		"when hitting the secondary rate limit, sleep for random": {
+			maxTries:        1,
+			sleeper:         nilSleeper,
+			errs:            []error{fmt.Errorf("You have exceeded a secondary rate limit. Please wait a few minutes")},
+			expectedResults: []bool{true},
+		},
 		"when the error is a github abuse rate limit error but max tries have been reached, don't retry": {
 			maxTries: 2,
 			sleeper:  nilSleeper,


### PR DESCRIPTION
This commit adds logic to the github call retrier to detect the GitHub
secondary rate limit. When detecting the limit, the github client
will wait for the set time (1 min) plus a few seconds more.

The idea behind this is that when doing calls in parallel we don't
want to set loose all workers to the API at the same time.

Permanent fix for https://github.com/kubernetes/release/pull/2324
Fixes https://github.com/kubernetes/release/issues/2225
Fixes https://github.com/kubernetes/release/issues/2302

/kind bug failing-test flake
/priority important-soon
/assign @justaugustus @Verolop @palnabarun @saschagrunert
/cc @kubernetes/release-engineering
/milestone v1.23

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>