### PR TITLE
git: Rename default git user to `k8s-release-robot`

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -66,8 +66,8 @@ const (
 	DefaultBranch = "master"
 
 	defaultGithubAuthRoot = "git@github.com:"
-	defaultGitUser        = "Anago GCB"
-	defaultGitEmail       = "nobody@k8s.io"
+	defaultGitUser        = "Kubernetes Release Robot"
+	defaultGitEmail       = "k8s-release-robot@users.noreply.github.com"
 	gitExecutable         = "git"
 )
 

--- a/git/git_integration_test.go
+++ b/git/git_integration_test.go
@@ -712,8 +712,16 @@ func TestCommitSuccess(t *testing.T) {
 	).Run()
 	require.Nil(t, err)
 	require.True(t, res.Success())
-	require.Contains(t, res.Output(), "Author: Anago GCB <nobody@k8s.io>")
-	require.Contains(t, res.Output(), commitMessage)
+	require.Contains(
+		t,
+		res.Output(),
+		"Author: Kubernetes Release Robot <k8s-release-robot@users.noreply.github.com>",
+	)
+	require.Contains(
+		t,
+		res.Output(),
+		commitMessage,
+	)
 }
 
 func TestCurrentBranchDefault(t *testing.T) {


### PR DESCRIPTION
We've removed `anago`, so we should stop impersonating it in git 🙃 

<img width="899" alt="Screen Shot 2021-12-10 at 16 26 15" src="https://user-images.githubusercontent.com/567897/145643381-64ca04c7-df7f-4783-94ff-b5cd3e6525d1.png">

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @puerco @Verolop 
cc: @kubernetes-sigs/release-engineering 