### PR TITLE
Add `LatestReleaseBranch()` and `RemoteBranches()` git API

### DIFF
--- a/git/git_integration_test.go
+++ b/git/git_integration_test.go
@@ -1001,3 +1001,12 @@ func TestTagSuccess(t *testing.T) {
 	require.Nil(t, err)
 	require.Contains(t, tags, testTag)
 }
+
+func TestLatestReleaseBranch(t *testing.T) {
+	testRepo := newTestRepo(t)
+	defer testRepo.cleanup(t)
+
+	branch, err := testRepo.sut.LatestReleaseBranch()
+	require.Nil(t, err)
+	require.Equal(t, testRepo.branchName, branch)
+}


### PR DESCRIPTION
We now add two API methods to the `git` package, which will be used for
the automatic fast forward of release branches.

Refers to https://github.com/kubernetes/release/issues/2386
