### PR TITLE
Add signing timeout

### DIFF
--- a/sign/impl.go
+++ b/sign/impl.go
@@ -19,7 +19,6 @@ package sign
 import (
 	"context"
 
-	"github.com/pkg/errors"
 	"github.com/sigstore/cosign/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/cmd/cosign/cli/sign"
 )
@@ -45,7 +44,8 @@ func (*defaultImpl) SignImageInternal(ctx context.Context, ko sign.KeyOpts, regO
 	annotations map[string]interface{}, imgs []string, certPath string, upload bool,
 	outputSignature string, outputCertificate string, payloadPath string, force bool,
 	recursive bool, attachment string) error {
-	err := sign.SignCmd(context.Background(), ko, regOpts, annotations, imgs, certPath, upload, outputSignature, outputCertificate, payloadPath, force, recursive, attachment)
-
-	return errors.Wrapf(err, "signing reference: %v", imgs)
+	return sign.SignCmd(
+		ctx, ko, regOpts, annotations, imgs, certPath, upload, outputSignature,
+		outputCertificate, payloadPath, force, recursive, attachment,
+	)
 }

--- a/sign/options.go
+++ b/sign/options.go
@@ -16,10 +16,17 @@ limitations under the License.
 
 package sign
 
+import "time"
+
 // Options can be used to modify the behavior of the signer.
 type Options struct {
 	// Verbose can be used to enable a higher log verbosity
-	Verbose               bool
+	Verbose bool
+
+	// Timeout is the default timeout for network operations.
+	// Defaults to 3 minutes
+	Timeout time.Duration
+
 	AllowInsecure         bool
 	OutputSignaturePath   string
 	OutputCertificatePath string
@@ -29,5 +36,7 @@ type Options struct {
 
 // Default returns a default Options instance.
 func Default() *Options {
-	return &Options{}
+	return &Options{
+		Timeout: 3 * time.Minute,
+	}
 }

--- a/sign/sign.go
+++ b/sign/sign.go
@@ -99,11 +99,14 @@ func (s *Signer) SignImage(reference string) (*SignedObject, error) {
 		outputCertificate = s.options.OutputCertificatePath
 	}
 
-	err := s.impl.SignImageInternal(context.Background(), ko, regOpts,
+	ctx, cancel := context.WithTimeout(context.Background(), s.options.Timeout)
+	defer cancel()
+
+	err := s.impl.SignImageInternal(ctx, ko, regOpts,
 		s.options.Annotations, imgs, "", true, outputSignature,
 		outputCertificate, "", true, false, "")
 	if err != nil {
-		return nil, errors.Wrapf(err, "verify reference: %s", reference)
+		return nil, errors.Wrapf(err, "sign reference: %s", reference)
 	}
 
 	object, err := s.impl.VerifyInternal(s, reference)


### PR DESCRIPTION
We should not block forever on the signing process if the network
flakes. This means we now use a default timeout of 3 minutes for each
signing invocation.

Follow-up on https://github.com/kubernetes-sigs/release-sdk/pull/25
Refers to https://github.com/kubernetes-sigs/release-sdk/issues/21