### PR TITLE
Catch os.SetEnv errors

### DIFF
--- a/sign/impl.go
+++ b/sign/impl.go
@@ -18,6 +18,7 @@ package sign
 
 import (
 	"context"
+	"os"
 
 	"github.com/sigstore/cosign/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/cmd/cosign/cli/sign"
@@ -34,6 +35,7 @@ type impl interface {
 		annotations map[string]interface{}, imgs []string, certPath string, upload bool,
 		outputSignature string, outputCertificate string, payloadPath string, force bool,
 		recursive bool, attachment string) error
+	Setenv(string, string) error
 }
 
 func (*defaultImpl) VerifyInternal(signer *Signer, reference string) (*SignedObject, error) {
@@ -48,4 +50,8 @@ func (*defaultImpl) SignImageInternal(ctx context.Context, ko sign.KeyOpts, regO
 		ctx, ko, regOpts, annotations, imgs, certPath, upload, outputSignature,
 		outputCertificate, payloadPath, force, recursive, attachment,
 	)
+}
+
+func (*defaultImpl) Setenv(key, value string) error {
+	return os.Setenv(key, value)
 }

--- a/sign/sign.go
+++ b/sign/sign.go
@@ -70,8 +70,14 @@ func (s *Signer) UploadBlob(path string) error {
 func (s *Signer) SignImage(reference string) (*SignedObject, error) {
 	s.log.Infof("Signing reference: %s", reference)
 
-	os.Setenv("COSIGN_EXPERIMENTAL", "true")
-	defer os.Setenv("COSIGN_EXPERIMENTAL", "")
+	if err := s.impl.Setenv("COSIGN_EXPERIMENTAL", "true"); err != nil {
+		return nil, errors.Wrap(err, "enable cosign experimental mode")
+	}
+	defer func() {
+		if err := s.impl.Setenv("COSIGN_EXPERIMENTAL", ""); err != nil {
+			s.log.Errorf("Unable to unset cosign experimental mode: %v", err)
+		}
+	}()
 
 	ko := sign.KeyOpts{
 		KeyRef:     s.options.KeyPath,

--- a/sign/sign_test.go
+++ b/sign/sign_test.go
@@ -72,6 +72,18 @@ func TestSignImage(t *testing.T) {
 				require.Nil(t, err)
 			},
 		},
+		{ // Success with failed unset experimental
+			prepare: func(mock *signfakes.FakeImpl) {
+				mock.VerifyInternalReturns(&sign.SignedObject{}, nil)
+				mock.SetenvReturnsOnCall(1, errTest)
+			},
+			assert: func(obj *sign.SignedObject, err error) {
+				require.NotNil(t, obj)
+				require.Empty(t, obj.Reference())
+				require.Empty(t, obj.Digest())
+				require.Nil(t, err)
+			},
+		},
 		{ // Failure on Verify
 			prepare: func(mock *signfakes.FakeImpl) {
 				mock.VerifyInternalReturns(nil, errTest)
@@ -86,6 +98,15 @@ func TestSignImage(t *testing.T) {
 			prepare: func(mock *signfakes.FakeImpl) {
 				mock.VerifyInternalReturns(&sign.SignedObject{}, nil)
 				mock.SignImageInternalReturns(errTest)
+			},
+			assert: func(obj *sign.SignedObject, err error) {
+				require.NotNil(t, err)
+				require.Nil(t, obj)
+			},
+		},
+		{ // Failure on set experimental
+			prepare: func(mock *signfakes.FakeImpl) {
+				mock.SetenvReturns(errTest)
 			},
 			assert: func(obj *sign.SignedObject, err error) {
 				require.NotNil(t, err)

--- a/sign/signfakes/fake_impl.go
+++ b/sign/signfakes/fake_impl.go
@@ -27,6 +27,18 @@ import (
 )
 
 type FakeImpl struct {
+	SetenvStub        func(string, string) error
+	setenvMutex       sync.RWMutex
+	setenvArgsForCall []struct {
+		arg1 string
+		arg2 string
+	}
+	setenvReturns struct {
+		result1 error
+	}
+	setenvReturnsOnCall map[int]struct {
+		result1 error
+	}
 	SignImageInternalStub        func(context.Context, signa.KeyOpts, options.RegistryOptions, map[string]interface{}, []string, string, bool, string, string, string, bool, bool, string) error
 	signImageInternalMutex       sync.RWMutex
 	signImageInternalArgsForCall []struct {
@@ -66,6 +78,68 @@ type FakeImpl struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeImpl) Setenv(arg1 string, arg2 string) error {
+	fake.setenvMutex.Lock()
+	ret, specificReturn := fake.setenvReturnsOnCall[len(fake.setenvArgsForCall)]
+	fake.setenvArgsForCall = append(fake.setenvArgsForCall, struct {
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	stub := fake.SetenvStub
+	fakeReturns := fake.setenvReturns
+	fake.recordInvocation("Setenv", []interface{}{arg1, arg2})
+	fake.setenvMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeImpl) SetenvCallCount() int {
+	fake.setenvMutex.RLock()
+	defer fake.setenvMutex.RUnlock()
+	return len(fake.setenvArgsForCall)
+}
+
+func (fake *FakeImpl) SetenvCalls(stub func(string, string) error) {
+	fake.setenvMutex.Lock()
+	defer fake.setenvMutex.Unlock()
+	fake.SetenvStub = stub
+}
+
+func (fake *FakeImpl) SetenvArgsForCall(i int) (string, string) {
+	fake.setenvMutex.RLock()
+	defer fake.setenvMutex.RUnlock()
+	argsForCall := fake.setenvArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeImpl) SetenvReturns(result1 error) {
+	fake.setenvMutex.Lock()
+	defer fake.setenvMutex.Unlock()
+	fake.SetenvStub = nil
+	fake.setenvReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeImpl) SetenvReturnsOnCall(i int, result1 error) {
+	fake.setenvMutex.Lock()
+	defer fake.setenvMutex.Unlock()
+	fake.SetenvStub = nil
+	if fake.setenvReturnsOnCall == nil {
+		fake.setenvReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.setenvReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeImpl) SignImageInternal(arg1 context.Context, arg2 signa.KeyOpts, arg3 options.RegistryOptions, arg4 map[string]interface{}, arg5 []string, arg6 string, arg7 bool, arg8 string, arg9 string, arg10 string, arg11 bool, arg12 bool, arg13 string) error {
@@ -214,6 +288,8 @@ func (fake *FakeImpl) VerifyInternalReturnsOnCall(i int, result1 *sign.SignedObj
 func (fake *FakeImpl) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.setenvMutex.RLock()
+	defer fake.setenvMutex.RUnlock()
 	fake.signImageInternalMutex.RLock()
 	defer fake.signImageInternalMutex.RUnlock()
 	fake.verifyInternalMutex.RLock()


### PR DESCRIPTION
We now test for issues on `os.SetEnv` as well as adding test around
those cases.

Follow-up on #25
Refers to #21