### PR TITLE
Split `Verify` API into `VerifyImage` and `VerifyFile`

### DIFF
--- a/sign/impl.go
+++ b/sign/impl.go
@@ -30,7 +30,8 @@ type defaultImpl struct{}
 //counterfeiter:generate . impl
 //go:generate /usr/bin/env bash -c "cat ../scripts/boilerplate/boilerplate.generatego.txt signfakes/fake_impl.go > signfakes/_fake_impl.go && mv signfakes/_fake_impl.go signfakes/fake_impl.go"
 type impl interface {
-	VerifyInternal(*Signer, string) (*SignedObject, error)
+	VerifyFileInternal(*Signer, string) (*SignedObject, error)
+	VerifyImageInternal(*Signer, string) (*SignedObject, error)
 	SignImageInternal(ctx context.Context, ko sign.KeyOpts, regOpts options.RegistryOptions,
 		annotations map[string]interface{}, imgs []string, certPath string, upload bool,
 		outputSignature string, outputCertificate string, payloadPath string, force bool,
@@ -38,8 +39,12 @@ type impl interface {
 	Setenv(string, string) error
 }
 
-func (*defaultImpl) VerifyInternal(signer *Signer, reference string) (*SignedObject, error) {
-	return signer.Verify(reference)
+func (*defaultImpl) VerifyFileInternal(signer *Signer, path string) (*SignedObject, error) {
+	return signer.VerifyFile(path)
+}
+
+func (*defaultImpl) VerifyImageInternal(signer *Signer, reference string) (*SignedObject, error) {
+	return signer.VerifyImage(reference)
 }
 
 func (*defaultImpl) SignImageInternal(ctx context.Context, ko sign.KeyOpts, regOpts options.RegistryOptions, // nolint: gocritic

--- a/sign/sign.go
+++ b/sign/sign.go
@@ -115,7 +115,7 @@ func (s *Signer) SignImage(reference string) (*SignedObject, error) {
 		return nil, errors.Wrapf(err, "sign reference: %s", reference)
 	}
 
-	object, err := s.impl.VerifyInternal(s, reference)
+	object, err := s.impl.VerifyImageInternal(s, reference)
 	if err != nil {
 		return nil, errors.Wrapf(err, "verify reference: %s", reference)
 	}
@@ -130,18 +130,25 @@ func (s *Signer) SignFile(path string) (*SignedObject, error) {
 
 	// TODO: unimplemented
 
-	object, err := s.impl.VerifyInternal(s, path)
+	object, err := s.impl.VerifyFileInternal(s, path)
 	if err != nil {
 		return nil, errors.Wrapf(err, "verify file path: %s", path)
 	}
 	return object, nil
 }
 
-// Verify can be used to validate any remote reference. The returned signed
-// object will contain additional information if the verification was
-// successful.
-func (s *Signer) Verify(reference string) (*SignedObject, error) {
+// VerifyImage can be used to validate any provided file path.
+func (s *Signer) VerifyImage(reference string) (*SignedObject, error) {
 	s.log.Infof("Verifying reference: %s", reference)
+
+	// TODO: unimplemented
+
+	return &SignedObject{}, nil
+}
+
+// VerifyFile can be used to validate any provided file path.
+func (s *Signer) VerifyFile(path string) (*SignedObject, error) {
+	s.log.Infof("Verifying file path: %s", path)
 
 	// TODO: unimplemented
 

--- a/sign/sign_test.go
+++ b/sign/sign_test.go
@@ -62,7 +62,7 @@ func TestSignImage(t *testing.T) {
 	}{
 		{ // Success
 			prepare: func(mock *signfakes.FakeImpl) {
-				mock.VerifyInternalReturns(&sign.SignedObject{}, nil)
+				mock.VerifyImageInternalReturns(&sign.SignedObject{}, nil)
 				mock.SignImageInternalReturns(nil)
 			},
 			assert: func(obj *sign.SignedObject, err error) {
@@ -74,7 +74,7 @@ func TestSignImage(t *testing.T) {
 		},
 		{ // Success with failed unset experimental
 			prepare: func(mock *signfakes.FakeImpl) {
-				mock.VerifyInternalReturns(&sign.SignedObject{}, nil)
+				mock.VerifyImageInternalReturns(&sign.SignedObject{}, nil)
 				mock.SetenvReturnsOnCall(1, errTest)
 			},
 			assert: func(obj *sign.SignedObject, err error) {
@@ -86,7 +86,7 @@ func TestSignImage(t *testing.T) {
 		},
 		{ // Failure on Verify
 			prepare: func(mock *signfakes.FakeImpl) {
-				mock.VerifyInternalReturns(nil, errTest)
+				mock.VerifyImageInternalReturns(nil, errTest)
 				mock.SignImageInternalReturns(nil)
 			},
 			assert: func(obj *sign.SignedObject, err error) {
@@ -96,7 +96,7 @@ func TestSignImage(t *testing.T) {
 		},
 		{ // Failure on Sign
 			prepare: func(mock *signfakes.FakeImpl) {
-				mock.VerifyInternalReturns(&sign.SignedObject{}, nil)
+				mock.VerifyImageInternalReturns(&sign.SignedObject{}, nil)
 				mock.SignImageInternalReturns(errTest)
 			},
 			assert: func(obj *sign.SignedObject, err error) {
@@ -137,7 +137,7 @@ func TestSignFile(t *testing.T) {
 	}{
 		{ // Success
 			prepare: func(mock *signfakes.FakeImpl) {
-				mock.VerifyInternalReturns(&sign.SignedObject{}, nil)
+				mock.VerifyFileInternalReturns(&sign.SignedObject{}, nil)
 			},
 			assert: func(obj *sign.SignedObject, err error) {
 				require.NotNil(t, obj)
@@ -148,7 +148,7 @@ func TestSignFile(t *testing.T) {
 		},
 		{ // Failure on Verify
 			prepare: func(mock *signfakes.FakeImpl) {
-				mock.VerifyInternalReturns(nil, errTest)
+				mock.VerifyFileInternalReturns(nil, errTest)
 			},
 			assert: func(obj *sign.SignedObject, err error) {
 				require.NotNil(t, err)
@@ -167,7 +167,7 @@ func TestSignFile(t *testing.T) {
 	}
 }
 
-func TestVerify(t *testing.T) {
+func TestVerifyImage(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {
@@ -188,7 +188,33 @@ func TestVerify(t *testing.T) {
 		sut := sign.New(sign.Default())
 		sut.SetImpl(mock)
 
-		obj, err := sut.Verify("")
+		obj, err := sut.VerifyImage("")
+		tc.assert(obj, err)
+	}
+}
+
+func TestVerifyFile(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		prepare func(*signfakes.FakeImpl)
+		assert  func(*sign.SignedObject, error)
+	}{
+		{ // Success
+			prepare: func(mock *signfakes.FakeImpl) {
+			},
+			assert: func(obj *sign.SignedObject, err error) {
+				require.Nil(t, err)
+			},
+		},
+	} {
+		mock := &signfakes.FakeImpl{}
+		tc.prepare(mock)
+
+		sut := sign.New(sign.Default())
+		sut.SetImpl(mock)
+
+		obj, err := sut.VerifyFile("")
 		tc.assert(obj, err)
 	}
 }

--- a/sign/signfakes/fake_impl.go
+++ b/sign/signfakes/fake_impl.go
@@ -62,17 +62,31 @@ type FakeImpl struct {
 	signImageInternalReturnsOnCall map[int]struct {
 		result1 error
 	}
-	VerifyInternalStub        func(*sign.Signer, string) (*sign.SignedObject, error)
-	verifyInternalMutex       sync.RWMutex
-	verifyInternalArgsForCall []struct {
+	VerifyFileInternalStub        func(*sign.Signer, string) (*sign.SignedObject, error)
+	verifyFileInternalMutex       sync.RWMutex
+	verifyFileInternalArgsForCall []struct {
 		arg1 *sign.Signer
 		arg2 string
 	}
-	verifyInternalReturns struct {
+	verifyFileInternalReturns struct {
 		result1 *sign.SignedObject
 		result2 error
 	}
-	verifyInternalReturnsOnCall map[int]struct {
+	verifyFileInternalReturnsOnCall map[int]struct {
+		result1 *sign.SignedObject
+		result2 error
+	}
+	VerifyImageInternalStub        func(*sign.Signer, string) (*sign.SignedObject, error)
+	verifyImageInternalMutex       sync.RWMutex
+	verifyImageInternalArgsForCall []struct {
+		arg1 *sign.Signer
+		arg2 string
+	}
+	verifyImageInternalReturns struct {
+		result1 *sign.SignedObject
+		result2 error
+	}
+	verifyImageInternalReturnsOnCall map[int]struct {
 		result1 *sign.SignedObject
 		result2 error
 	}
@@ -220,17 +234,17 @@ func (fake *FakeImpl) SignImageInternalReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeImpl) VerifyInternal(arg1 *sign.Signer, arg2 string) (*sign.SignedObject, error) {
-	fake.verifyInternalMutex.Lock()
-	ret, specificReturn := fake.verifyInternalReturnsOnCall[len(fake.verifyInternalArgsForCall)]
-	fake.verifyInternalArgsForCall = append(fake.verifyInternalArgsForCall, struct {
+func (fake *FakeImpl) VerifyFileInternal(arg1 *sign.Signer, arg2 string) (*sign.SignedObject, error) {
+	fake.verifyFileInternalMutex.Lock()
+	ret, specificReturn := fake.verifyFileInternalReturnsOnCall[len(fake.verifyFileInternalArgsForCall)]
+	fake.verifyFileInternalArgsForCall = append(fake.verifyFileInternalArgsForCall, struct {
 		arg1 *sign.Signer
 		arg2 string
 	}{arg1, arg2})
-	stub := fake.VerifyInternalStub
-	fakeReturns := fake.verifyInternalReturns
-	fake.recordInvocation("VerifyInternal", []interface{}{arg1, arg2})
-	fake.verifyInternalMutex.Unlock()
+	stub := fake.VerifyFileInternalStub
+	fakeReturns := fake.verifyFileInternalReturns
+	fake.recordInvocation("VerifyFileInternal", []interface{}{arg1, arg2})
+	fake.verifyFileInternalMutex.Unlock()
 	if stub != nil {
 		return stub(arg1, arg2)
 	}
@@ -240,46 +254,111 @@ func (fake *FakeImpl) VerifyInternal(arg1 *sign.Signer, arg2 string) (*sign.Sign
 	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeImpl) VerifyInternalCallCount() int {
-	fake.verifyInternalMutex.RLock()
-	defer fake.verifyInternalMutex.RUnlock()
-	return len(fake.verifyInternalArgsForCall)
+func (fake *FakeImpl) VerifyFileInternalCallCount() int {
+	fake.verifyFileInternalMutex.RLock()
+	defer fake.verifyFileInternalMutex.RUnlock()
+	return len(fake.verifyFileInternalArgsForCall)
 }
 
-func (fake *FakeImpl) VerifyInternalCalls(stub func(*sign.Signer, string) (*sign.SignedObject, error)) {
-	fake.verifyInternalMutex.Lock()
-	defer fake.verifyInternalMutex.Unlock()
-	fake.VerifyInternalStub = stub
+func (fake *FakeImpl) VerifyFileInternalCalls(stub func(*sign.Signer, string) (*sign.SignedObject, error)) {
+	fake.verifyFileInternalMutex.Lock()
+	defer fake.verifyFileInternalMutex.Unlock()
+	fake.VerifyFileInternalStub = stub
 }
 
-func (fake *FakeImpl) VerifyInternalArgsForCall(i int) (*sign.Signer, string) {
-	fake.verifyInternalMutex.RLock()
-	defer fake.verifyInternalMutex.RUnlock()
-	argsForCall := fake.verifyInternalArgsForCall[i]
+func (fake *FakeImpl) VerifyFileInternalArgsForCall(i int) (*sign.Signer, string) {
+	fake.verifyFileInternalMutex.RLock()
+	defer fake.verifyFileInternalMutex.RUnlock()
+	argsForCall := fake.verifyFileInternalArgsForCall[i]
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeImpl) VerifyInternalReturns(result1 *sign.SignedObject, result2 error) {
-	fake.verifyInternalMutex.Lock()
-	defer fake.verifyInternalMutex.Unlock()
-	fake.VerifyInternalStub = nil
-	fake.verifyInternalReturns = struct {
+func (fake *FakeImpl) VerifyFileInternalReturns(result1 *sign.SignedObject, result2 error) {
+	fake.verifyFileInternalMutex.Lock()
+	defer fake.verifyFileInternalMutex.Unlock()
+	fake.VerifyFileInternalStub = nil
+	fake.verifyFileInternalReturns = struct {
 		result1 *sign.SignedObject
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeImpl) VerifyInternalReturnsOnCall(i int, result1 *sign.SignedObject, result2 error) {
-	fake.verifyInternalMutex.Lock()
-	defer fake.verifyInternalMutex.Unlock()
-	fake.VerifyInternalStub = nil
-	if fake.verifyInternalReturnsOnCall == nil {
-		fake.verifyInternalReturnsOnCall = make(map[int]struct {
+func (fake *FakeImpl) VerifyFileInternalReturnsOnCall(i int, result1 *sign.SignedObject, result2 error) {
+	fake.verifyFileInternalMutex.Lock()
+	defer fake.verifyFileInternalMutex.Unlock()
+	fake.VerifyFileInternalStub = nil
+	if fake.verifyFileInternalReturnsOnCall == nil {
+		fake.verifyFileInternalReturnsOnCall = make(map[int]struct {
 			result1 *sign.SignedObject
 			result2 error
 		})
 	}
-	fake.verifyInternalReturnsOnCall[i] = struct {
+	fake.verifyFileInternalReturnsOnCall[i] = struct {
+		result1 *sign.SignedObject
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeImpl) VerifyImageInternal(arg1 *sign.Signer, arg2 string) (*sign.SignedObject, error) {
+	fake.verifyImageInternalMutex.Lock()
+	ret, specificReturn := fake.verifyImageInternalReturnsOnCall[len(fake.verifyImageInternalArgsForCall)]
+	fake.verifyImageInternalArgsForCall = append(fake.verifyImageInternalArgsForCall, struct {
+		arg1 *sign.Signer
+		arg2 string
+	}{arg1, arg2})
+	stub := fake.VerifyImageInternalStub
+	fakeReturns := fake.verifyImageInternalReturns
+	fake.recordInvocation("VerifyImageInternal", []interface{}{arg1, arg2})
+	fake.verifyImageInternalMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeImpl) VerifyImageInternalCallCount() int {
+	fake.verifyImageInternalMutex.RLock()
+	defer fake.verifyImageInternalMutex.RUnlock()
+	return len(fake.verifyImageInternalArgsForCall)
+}
+
+func (fake *FakeImpl) VerifyImageInternalCalls(stub func(*sign.Signer, string) (*sign.SignedObject, error)) {
+	fake.verifyImageInternalMutex.Lock()
+	defer fake.verifyImageInternalMutex.Unlock()
+	fake.VerifyImageInternalStub = stub
+}
+
+func (fake *FakeImpl) VerifyImageInternalArgsForCall(i int) (*sign.Signer, string) {
+	fake.verifyImageInternalMutex.RLock()
+	defer fake.verifyImageInternalMutex.RUnlock()
+	argsForCall := fake.verifyImageInternalArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeImpl) VerifyImageInternalReturns(result1 *sign.SignedObject, result2 error) {
+	fake.verifyImageInternalMutex.Lock()
+	defer fake.verifyImageInternalMutex.Unlock()
+	fake.VerifyImageInternalStub = nil
+	fake.verifyImageInternalReturns = struct {
+		result1 *sign.SignedObject
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeImpl) VerifyImageInternalReturnsOnCall(i int, result1 *sign.SignedObject, result2 error) {
+	fake.verifyImageInternalMutex.Lock()
+	defer fake.verifyImageInternalMutex.Unlock()
+	fake.VerifyImageInternalStub = nil
+	if fake.verifyImageInternalReturnsOnCall == nil {
+		fake.verifyImageInternalReturnsOnCall = make(map[int]struct {
+			result1 *sign.SignedObject
+			result2 error
+		})
+	}
+	fake.verifyImageInternalReturnsOnCall[i] = struct {
 		result1 *sign.SignedObject
 		result2 error
 	}{result1, result2}
@@ -292,8 +371,10 @@ func (fake *FakeImpl) Invocations() map[string][][]interface{} {
 	defer fake.setenvMutex.RUnlock()
 	fake.signImageInternalMutex.RLock()
 	defer fake.signImageInternalMutex.RUnlock()
-	fake.verifyInternalMutex.RLock()
-	defer fake.verifyInternalMutex.RUnlock()
+	fake.verifyFileInternalMutex.RLock()
+	defer fake.verifyFileInternalMutex.RUnlock()
+	fake.verifyImageInternalMutex.RLock()
+	defer fake.verifyImageInternalMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value


### PR DESCRIPTION
### Why
- Based on slack conversation here: https://kubernetes.slack.com/archives/C2C40FMNF/p1644342988804439?thread_ts=1644269088.802199&cid=C2C40FMNF 
- Keep in sync with https://github.com/kubernetes-sigs/release-sdk/pull/20

@palnabarun this may impact / need rebase for your #29 