### PR TITLE
Move Git integration tests to the test/integration pkg

### DIFF
--- a/git/git_test.go
+++ b/git/git_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
@@ -34,6 +35,12 @@ import (
 	"sigs.k8s.io/release-sdk/git/gitfakes"
 	"sigs.k8s.io/release-utils/command"
 )
+
+var testAuthor = &object.Signature{
+	Name:  "John Doe",
+	Email: "john@doe.org",
+	When:  time.Now(),
+}
 
 func newSUT() (*git.Repo, *gitfakes.FakeWorktree) {
 	repoMock := &gitfakes.FakeRepository{}

--- a/test/integration/git_test.go
+++ b/test/integration/git_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 /*
 Copyright 2019 The Kubernetes Authors.
 
@@ -14,7 +17,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package git_test
+package integration
 
 import (
 	"os"


### PR DESCRIPTION
We introduced the `IntegrationTest` target in #31 which is supposed to be used for running the integration tests. The Test target is supposed to be used for running the unit tests.

Therefore, this PR moves the Git integration from `Test` to `IntegrationTest` (and `pkg/integration`).

/assign @puerco @saschagrunert @cpanato 
cc @kubernetes-sigs/release-engineering 