### PR TITLE
sign: IsImageSigned()

### DIFF
--- a/sign/impl_test.go
+++ b/sign/impl_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sign
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsImageSigned(t *testing.T) {
+	signer := New(Default())
+	for _, tc := range []struct {
+		imageRef  string
+		isSigned  bool
+		shouldErr bool
+	}{
+		{
+			// cosign ~1.5.2 signed image
+			"ghcr.io/sigstore/cosign/cosign:f436d7637caaa9073522ae65a8416e38cd69c4f2", true, false,
+		},
+		{
+			// k8s/pause ~feb 13 2022. mot signed
+			"k8s.gcr.io/pause@sha256:a78c2d6208eff9b672de43f880093100050983047b7b0afe0217d3656e1b0d5f", false, true,
+		},
+		{
+			// nonexistent image, must fail
+			"kornotios/supermegafakeimage", false, true,
+		},
+	} {
+		res, err := signer.IsImageSigned(tc.imageRef)
+		require.Equal(t, tc.isSigned, res, fmt.Sprintf("Checking %s for signature", tc.imageRef))
+		if tc.shouldErr {
+			require.Error(t, err)
+		} else {
+			require.NoError(t, err)
+		}
+	}
+}

--- a/sign/sign.go
+++ b/sign/sign.go
@@ -177,3 +177,13 @@ func (s *Signer) enableExperimental() (resetFn func(), err error) {
 		}
 	}, nil
 }
+
+// IsImageSigned takes an image reference and returns true if there are
+// signatures available for it. It makes no signature verification, only
+// checks to see if more than one signature is available.
+func (s *Signer) IsImageSigned(imageRef string) (bool, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), s.options.Timeout)
+	defer cancel()
+
+	return s.impl.IsImageSignedInternal(ctx, imageRef)
+}

--- a/sign/signfakes/fake_impl.go
+++ b/sign/signfakes/fake_impl.go
@@ -39,6 +39,20 @@ type FakeImpl struct {
 	envDefaultReturnsOnCall map[int]struct {
 		result1 string
 	}
+	IsImageSignedInternalStub        func(context.Context, string) (bool, error)
+	isImageSignedInternalMutex       sync.RWMutex
+	isImageSignedInternalArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+	}
+	isImageSignedInternalReturns struct {
+		result1 bool
+		result2 error
+	}
+	isImageSignedInternalReturnsOnCall map[int]struct {
+		result1 bool
+		result2 error
+	}
 	SetenvStub        func(string, string) error
 	setenvMutex       sync.RWMutex
 	setenvArgsForCall []struct {
@@ -167,6 +181,71 @@ func (fake *FakeImpl) EnvDefaultReturnsOnCall(i int, result1 string) {
 	fake.envDefaultReturnsOnCall[i] = struct {
 		result1 string
 	}{result1}
+}
+
+func (fake *FakeImpl) IsImageSignedInternal(arg1 context.Context, arg2 string) (bool, error) {
+	fake.isImageSignedInternalMutex.Lock()
+	ret, specificReturn := fake.isImageSignedInternalReturnsOnCall[len(fake.isImageSignedInternalArgsForCall)]
+	fake.isImageSignedInternalArgsForCall = append(fake.isImageSignedInternalArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+	}{arg1, arg2})
+	stub := fake.IsImageSignedInternalStub
+	fakeReturns := fake.isImageSignedInternalReturns
+	fake.recordInvocation("IsImageSignedInternal", []interface{}{arg1, arg2})
+	fake.isImageSignedInternalMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeImpl) IsImageSignedInternalCallCount() int {
+	fake.isImageSignedInternalMutex.RLock()
+	defer fake.isImageSignedInternalMutex.RUnlock()
+	return len(fake.isImageSignedInternalArgsForCall)
+}
+
+func (fake *FakeImpl) IsImageSignedInternalCalls(stub func(context.Context, string) (bool, error)) {
+	fake.isImageSignedInternalMutex.Lock()
+	defer fake.isImageSignedInternalMutex.Unlock()
+	fake.IsImageSignedInternalStub = stub
+}
+
+func (fake *FakeImpl) IsImageSignedInternalArgsForCall(i int) (context.Context, string) {
+	fake.isImageSignedInternalMutex.RLock()
+	defer fake.isImageSignedInternalMutex.RUnlock()
+	argsForCall := fake.isImageSignedInternalArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeImpl) IsImageSignedInternalReturns(result1 bool, result2 error) {
+	fake.isImageSignedInternalMutex.Lock()
+	defer fake.isImageSignedInternalMutex.Unlock()
+	fake.IsImageSignedInternalStub = nil
+	fake.isImageSignedInternalReturns = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeImpl) IsImageSignedInternalReturnsOnCall(i int, result1 bool, result2 error) {
+	fake.isImageSignedInternalMutex.Lock()
+	defer fake.isImageSignedInternalMutex.Unlock()
+	fake.IsImageSignedInternalStub = nil
+	if fake.isImageSignedInternalReturnsOnCall == nil {
+		fake.isImageSignedInternalReturnsOnCall = make(map[int]struct {
+			result1 bool
+			result2 error
+		})
+	}
+	fake.isImageSignedInternalReturnsOnCall[i] = struct {
+		result1 bool
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeImpl) Setenv(arg1 string, arg2 string) error {
@@ -450,6 +529,8 @@ func (fake *FakeImpl) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.envDefaultMutex.RLock()
 	defer fake.envDefaultMutex.RUnlock()
+	fake.isImageSignedInternalMutex.RLock()
+	defer fake.isImageSignedInternalMutex.RUnlock()
 	fake.setenvMutex.RLock()
 	defer fake.setenvMutex.RUnlock()
 	fake.signImageInternalMutex.RLock()


### PR DESCRIPTION
Thit PR introduces a new method to the signer object `IsImageSigned()` which returns a bool indicating if an image reference has signatures attached to it.

This is needed because we need to know if images are signed before triggering image verification on a reference.

Needed for verifying images in the container image promoter: https://github.com/kubernetes-sigs/promo-tools/pull/498

Related to
https://github.com/kubernetes/release/issues/2383
https://github.com/kubernetes/release/issues/2227

/cc @saschagrunert @cpanato @xmudrii @PushkarJ @palnabarun   

```release-note
New signer method `IsImageSigned()` allows tp check if an image reference has one or more digital signatures attached.
```