### PR TITLE
sign: Use cosign's OCI Remote to check for signatures

### DIFF
--- a/sign/impl_test.go
+++ b/sign/impl_test.go
@@ -35,8 +35,8 @@ func TestIsImageSigned(t *testing.T) {
 			"ghcr.io/sigstore/cosign/cosign:f436d7637caaa9073522ae65a8416e38cd69c4f2", true, false,
 		},
 		{
-			// k8s/pause ~feb 13 2022. mot signed
-			"k8s.gcr.io/pause@sha256:a78c2d6208eff9b672de43f880093100050983047b7b0afe0217d3656e1b0d5f", false, true,
+			// k8s/pause ~feb 13 2022. not signed
+			"k8s.gcr.io/pause@sha256:a78c2d6208eff9b672de43f880093100050983047b7b0afe0217d3656e1b0d5f", false, false,
 		},
 		{
 			// nonexistent image, must fail


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR fixes a bug in the IsSignedImage() function and also modifies the IsImageSignedInternal function to use the OCI remote package in cosign to check for signatures. This means that the implementation now uses a more primitive API saving a layer of abstraction on top of it.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

/cc @saschagrunert @cpanato @xmudrii @PushkarJ @palnabarun

#### Does this PR introduce a user-facing change?

```release-note
Fixed a bug when checking if images are signed and by the way switched the signer implementation to use the OCI remote package from cosign.
```
