### PR TITLE
Signer: Support external OIDC tokens. Fail early if token missing.

### DIFF
--- a/sign/impl.go
+++ b/sign/impl.go
@@ -33,7 +33,9 @@ import (
 	"sigs.k8s.io/release-utils/util"
 )
 
-type defaultImpl struct{}
+type defaultImpl struct {
+	log *logrus.Logger
+}
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 //counterfeiter:generate . impl
@@ -110,9 +112,9 @@ func (*defaultImpl) IsImageSignedInternal(
 
 // TokenFromProviders will try the cosign OIDC providers to get an
 // oidc token from them.
-func (*defaultImpl) TokenFromProviders(ctx context.Context) (string, error) {
+func (di *defaultImpl) TokenFromProviders(ctx context.Context) (string, error) {
 	if !providers.Enabled(ctx) {
-		logrus.Warn("No OIDC provider enabled. Token cannot be obtained autmatically.")
+		di.log.Warn("No OIDC provider enabled. Token cannot be obtained autmatically.")
 		return "", nil
 	}
 

--- a/sign/impl.go
+++ b/sign/impl.go
@@ -113,7 +113,7 @@ func (*defaultImpl) IsImageSignedInternal(
 // TokenFromProviders will try the cosign OIDC providers to get an
 // oidc token from them.
 func (di *defaultImpl) TokenFromProviders(ctx context.Context) (string, error) {
-	if !providers.Enabled(ctx) {
+	if !di.IdentityProvidersEnabled(ctx) {
 		di.log.Warn("No OIDC provider enabled. Token cannot be obtained autmatically.")
 		return "", nil
 	}
@@ -128,4 +128,11 @@ func (di *defaultImpl) TokenFromProviders(ctx context.Context) (string, error) {
 // FileExists returns true if a file exists
 func (*defaultImpl) FileExists(path string) bool {
 	return util.Exists(path)
+}
+
+// IdentityProvidersEnabled returns true if any of the cosign
+// identity providers is able to obteain an OIDC identity token
+// suitable for keyless signing,
+func (*defaultImpl) IdentityProvidersEnabled(ctx context.Context) bool {
+	return providers.Enabled(ctx)
 }

--- a/sign/impl.go
+++ b/sign/impl.go
@@ -30,6 +30,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/release-utils/env"
+	"sigs.k8s.io/release-utils/util"
 )
 
 type defaultImpl struct{}
@@ -48,6 +49,7 @@ type impl interface {
 	Setenv(string, string) error
 	EnvDefault(string, string) string
 	TokenFromProviders(context.Context) (string, error)
+	FileExists(string) bool
 }
 
 func (*defaultImpl) VerifyFileInternal(signer *Signer, path string) (*SignedObject, error) {
@@ -119,4 +121,9 @@ func (*defaultImpl) TokenFromProviders(ctx context.Context) (string, error) {
 		return "", errors.Wrap(err, "fetching oidc token from environment")
 	}
 	return tok, nil
+}
+
+// FileExists returns true if a file exists
+func (*defaultImpl) FileExists(path string) bool {
+	return util.Exists(path)
 }

--- a/sign/impl_test.go
+++ b/sign/impl_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -59,7 +60,7 @@ func TestFileExists(t *testing.T) {
 	require.NoError(t, err)
 	defer os.Remove(f.Name())
 	require.NoError(t, os.WriteFile(f.Name(), []byte("hey"), os.FileMode(0o644)))
-	sut := defaultImpl{}
+	sut := &defaultImpl{log: logrus.New()}
 	require.True(t, sut.FileExists(f.Name()))
 	require.False(t, sut.FileExists(f.Name()+"a"))
 }

--- a/sign/impl_test.go
+++ b/sign/impl_test.go
@@ -18,6 +18,7 @@ package sign
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -51,4 +52,14 @@ func TestIsImageSigned(t *testing.T) {
 			require.NoError(t, err)
 		}
 	}
+}
+
+func TestFileExists(t *testing.T) {
+	f, err := os.CreateTemp("", "test-")
+	require.NoError(t, err)
+	defer os.Remove(f.Name())
+	require.NoError(t, os.WriteFile(f.Name(), []byte("hey"), os.FileMode(0o644)))
+	sut := defaultImpl{}
+	require.True(t, sut.FileExists(f.Name()))
+	require.False(t, sut.FileExists(f.Name()+"a"))
 }

--- a/sign/options.go
+++ b/sign/options.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/sigstore/cosign/cmd/cosign/cli/generate"
 	"github.com/sigstore/cosign/pkg/cosign"
-	"sigs.k8s.io/release-utils/util"
 )
 
 // Options can be used to modify the behavior of the signer.
@@ -75,7 +74,8 @@ func (o *Options) verifySignOptions() error {
 	}
 
 	// Ensure that the private key file exists
-	if o.PrivateKeyPath != "" && !util.Exists(o.PrivateKeyPath) {
+	i := defaultImpl{}
+	if o.PrivateKeyPath != "" && !i.FileExists(o.PrivateKeyPath) {
 		return errors.New("specified private key file not found")
 	}
 	return nil

--- a/sign/options.go
+++ b/sign/options.go
@@ -17,10 +17,12 @@ limitations under the License.
 package sign
 
 import (
+	"errors"
 	"time"
 
 	"github.com/sigstore/cosign/cmd/cosign/cli/generate"
 	"github.com/sigstore/cosign/pkg/cosign"
+	"sigs.k8s.io/release-utils/util"
 )
 
 // Options can be used to modify the behavior of the signer.
@@ -39,6 +41,13 @@ type Options struct {
 	PrivateKeyPath        string
 	PublicKeyPath         string
 
+	// Identity token for keyless signing
+	IdentityToken string
+
+	// EnableTokenProviders tells signer to try to get a
+	// token from the cosign providers when needed.
+	EnableTokenProviders bool
+
 	// PassFunc is a function that returns a slice of bytes that will be used
 	// as a password for decrypting the cosign key. It is used only if PrivateKeyPath
 	// is provided (i.e. it's not used for keyless signing).
@@ -49,7 +58,25 @@ type Options struct {
 // Default returns a default Options instance.
 func Default() *Options {
 	return &Options{
-		Timeout:  3 * time.Minute,
-		PassFunc: generate.GetPass,
+		Timeout:              3 * time.Minute,
+		PassFunc:             generate.GetPass,
+		EnableTokenProviders: true,
 	}
+}
+
+// verifySignOptions checks that options have the minimum settings
+// for signing files or images:
+func (o *Options) verifySignOptions() error {
+	// Our library is not designed to run in interactive mode
+	// this means that we will only support signing if we get a keypair or
+	// identity token to run keyless signing:
+	if o.PrivateKeyPath != "" && o.IdentityToken == "" && !o.EnableTokenProviders {
+		return errors.New("signing can only be done if a key or identity token are set")
+	}
+
+	// Ensure that the private key file exists
+	if o.PrivateKeyPath != "" && !util.Exists(o.PrivateKeyPath) {
+		return errors.New("specified private key file not found")
+	}
+	return nil
 }

--- a/sign/options.go
+++ b/sign/options.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/sigstore/cosign/cmd/cosign/cli/generate"
 	"github.com/sigstore/cosign/pkg/cosign"
+	"github.com/sirupsen/logrus"
 )
 
 // Options can be used to modify the behavior of the signer.
@@ -74,7 +75,9 @@ func (o *Options) verifySignOptions() error {
 	}
 
 	// Ensure that the private key file exists
-	i := defaultImpl{}
+	i := defaultImpl{
+		log: logrus.New(),
+	}
 	if o.PrivateKeyPath != "" && !i.FileExists(o.PrivateKeyPath) {
 		return errors.New("specified private key file not found")
 	}

--- a/sign/sign.go
+++ b/sign/sign.go
@@ -44,7 +44,9 @@ func New(options *Options) *Signer {
 	}
 
 	return &Signer{
-		impl:    &defaultImpl{},
+		impl: &defaultImpl{
+			log: logger,
+		},
 		options: options,
 		log:     logger,
 	}

--- a/sign/sign.go
+++ b/sign/sign.go
@@ -69,14 +69,37 @@ func (s *Signer) UploadBlob(path string) error {
 func (s *Signer) SignImage(reference string) (*SignedObject, error) {
 	s.log.Infof("Signing reference: %s", reference)
 
+	// Ensure options to sign are correct
+	if err := s.options.verifySignOptions(); err != nil {
+		return nil, errors.Wrap(err, "checking signing options")
+	}
+
 	resetFn, err := s.enableExperimental()
 	if err != nil {
 		return nil, err
 	}
 	defer resetFn()
 
+	// If we don't have a key path, we must ensure we can get an OIDC
+	// token or there is no way to sign. Depending on the options set,
+	// we may get the ID token from the cosign providers
+	identityToken := ""
+	if s.options.PrivateKeyPath == "" {
+		tok, err := s.identityToken()
+		if err != nil {
+			return nil, errors.Wrap(err, "getting identity token for keyless signing")
+		}
+		identityToken = tok
+		if identityToken == "" {
+			return nil, errors.New(
+				"no private key or identity token are available, unable to sign",
+			)
+		}
+	}
+
 	ko := sign.KeyOpts{
 		KeyRef:     s.options.PrivateKeyPath,
+		IDToken:    identityToken,
 		PassFunc:   s.options.PassFunc,
 		FulcioURL:  cliOpts.DefaultFulcioURL,
 		RekorURL:   cliOpts.DefaultRekorURL,
@@ -186,4 +209,27 @@ func (s *Signer) IsImageSigned(imageRef string) (bool, error) {
 	defer cancel()
 
 	return s.impl.IsImageSignedInternal(ctx, imageRef)
+}
+
+// identityToken returns an identity token to perform keyless signing.
+// If there is one set in the options we will use that one. If not,
+// signer will try to get one from the cosign OIDC identity providers
+// if options.EnableTokenProviders is set
+func (s *Signer) identityToken() (string, error) {
+	tok := s.options.IdentityToken
+	if s.options.PrivateKeyPath == "" && s.options.IdentityToken == "" {
+		// We only attempt to pull from the providers if the option is set
+		if !s.options.EnableTokenProviders {
+			logrus.Warn("No token set in options and OIDC providers are disabled")
+			return "", nil
+		}
+
+		logrus.Info("No identity token was provided. Attempting to get one from supported providers.")
+		token, err := s.impl.TokenFromProviders(context.Background())
+		if err != nil {
+			return "", errors.Wrap(err, "getting identity token from providers")
+		}
+		tok = token
+	}
+	return tok, nil
 }

--- a/sign/signfakes/fake_impl.go
+++ b/sign/signfakes/fake_impl.go
@@ -88,6 +88,19 @@ type FakeImpl struct {
 	signImageInternalReturnsOnCall map[int]struct {
 		result1 error
 	}
+	TokenFromProvidersStub        func(context.Context) (string, error)
+	tokenFromProvidersMutex       sync.RWMutex
+	tokenFromProvidersArgsForCall []struct {
+		arg1 context.Context
+	}
+	tokenFromProvidersReturns struct {
+		result1 string
+		result2 error
+	}
+	tokenFromProvidersReturnsOnCall map[int]struct {
+		result1 string
+		result2 error
+	}
 	VerifyFileInternalStub        func(*sign.Signer, string) (*sign.SignedObject, error)
 	verifyFileInternalMutex       sync.RWMutex
 	verifyFileInternalArgsForCall []struct {
@@ -388,6 +401,70 @@ func (fake *FakeImpl) SignImageInternalReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *FakeImpl) TokenFromProviders(arg1 context.Context) (string, error) {
+	fake.tokenFromProvidersMutex.Lock()
+	ret, specificReturn := fake.tokenFromProvidersReturnsOnCall[len(fake.tokenFromProvidersArgsForCall)]
+	fake.tokenFromProvidersArgsForCall = append(fake.tokenFromProvidersArgsForCall, struct {
+		arg1 context.Context
+	}{arg1})
+	stub := fake.TokenFromProvidersStub
+	fakeReturns := fake.tokenFromProvidersReturns
+	fake.recordInvocation("TokenFromProviders", []interface{}{arg1})
+	fake.tokenFromProvidersMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeImpl) TokenFromProvidersCallCount() int {
+	fake.tokenFromProvidersMutex.RLock()
+	defer fake.tokenFromProvidersMutex.RUnlock()
+	return len(fake.tokenFromProvidersArgsForCall)
+}
+
+func (fake *FakeImpl) TokenFromProvidersCalls(stub func(context.Context) (string, error)) {
+	fake.tokenFromProvidersMutex.Lock()
+	defer fake.tokenFromProvidersMutex.Unlock()
+	fake.TokenFromProvidersStub = stub
+}
+
+func (fake *FakeImpl) TokenFromProvidersArgsForCall(i int) context.Context {
+	fake.tokenFromProvidersMutex.RLock()
+	defer fake.tokenFromProvidersMutex.RUnlock()
+	argsForCall := fake.tokenFromProvidersArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeImpl) TokenFromProvidersReturns(result1 string, result2 error) {
+	fake.tokenFromProvidersMutex.Lock()
+	defer fake.tokenFromProvidersMutex.Unlock()
+	fake.TokenFromProvidersStub = nil
+	fake.tokenFromProvidersReturns = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeImpl) TokenFromProvidersReturnsOnCall(i int, result1 string, result2 error) {
+	fake.tokenFromProvidersMutex.Lock()
+	defer fake.tokenFromProvidersMutex.Unlock()
+	fake.TokenFromProvidersStub = nil
+	if fake.tokenFromProvidersReturnsOnCall == nil {
+		fake.tokenFromProvidersReturnsOnCall = make(map[int]struct {
+			result1 string
+			result2 error
+		})
+	}
+	fake.tokenFromProvidersReturnsOnCall[i] = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeImpl) VerifyFileInternal(arg1 *sign.Signer, arg2 string) (*sign.SignedObject, error) {
 	fake.verifyFileInternalMutex.Lock()
 	ret, specificReturn := fake.verifyFileInternalReturnsOnCall[len(fake.verifyFileInternalArgsForCall)]
@@ -535,6 +612,8 @@ func (fake *FakeImpl) Invocations() map[string][][]interface{} {
 	defer fake.setenvMutex.RUnlock()
 	fake.signImageInternalMutex.RLock()
 	defer fake.signImageInternalMutex.RUnlock()
+	fake.tokenFromProvidersMutex.RLock()
+	defer fake.tokenFromProvidersMutex.RUnlock()
 	fake.verifyFileInternalMutex.RLock()
 	defer fake.verifyFileInternalMutex.RUnlock()
 	fake.verifyImageInternalMutex.RLock()

--- a/sign/signfakes/fake_impl.go
+++ b/sign/signfakes/fake_impl.go
@@ -39,6 +39,17 @@ type FakeImpl struct {
 	envDefaultReturnsOnCall map[int]struct {
 		result1 string
 	}
+	FileExistsStub        func(string) bool
+	fileExistsMutex       sync.RWMutex
+	fileExistsArgsForCall []struct {
+		arg1 string
+	}
+	fileExistsReturns struct {
+		result1 bool
+	}
+	fileExistsReturnsOnCall map[int]struct {
+		result1 bool
+	}
 	IsImageSignedInternalStub        func(context.Context, string) (bool, error)
 	isImageSignedInternalMutex       sync.RWMutex
 	isImageSignedInternalArgsForCall []struct {
@@ -193,6 +204,67 @@ func (fake *FakeImpl) EnvDefaultReturnsOnCall(i int, result1 string) {
 	}
 	fake.envDefaultReturnsOnCall[i] = struct {
 		result1 string
+	}{result1}
+}
+
+func (fake *FakeImpl) FileExists(arg1 string) bool {
+	fake.fileExistsMutex.Lock()
+	ret, specificReturn := fake.fileExistsReturnsOnCall[len(fake.fileExistsArgsForCall)]
+	fake.fileExistsArgsForCall = append(fake.fileExistsArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.FileExistsStub
+	fakeReturns := fake.fileExistsReturns
+	fake.recordInvocation("FileExists", []interface{}{arg1})
+	fake.fileExistsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeImpl) FileExistsCallCount() int {
+	fake.fileExistsMutex.RLock()
+	defer fake.fileExistsMutex.RUnlock()
+	return len(fake.fileExistsArgsForCall)
+}
+
+func (fake *FakeImpl) FileExistsCalls(stub func(string) bool) {
+	fake.fileExistsMutex.Lock()
+	defer fake.fileExistsMutex.Unlock()
+	fake.FileExistsStub = stub
+}
+
+func (fake *FakeImpl) FileExistsArgsForCall(i int) string {
+	fake.fileExistsMutex.RLock()
+	defer fake.fileExistsMutex.RUnlock()
+	argsForCall := fake.fileExistsArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeImpl) FileExistsReturns(result1 bool) {
+	fake.fileExistsMutex.Lock()
+	defer fake.fileExistsMutex.Unlock()
+	fake.FileExistsStub = nil
+	fake.fileExistsReturns = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeImpl) FileExistsReturnsOnCall(i int, result1 bool) {
+	fake.fileExistsMutex.Lock()
+	defer fake.fileExistsMutex.Unlock()
+	fake.FileExistsStub = nil
+	if fake.fileExistsReturnsOnCall == nil {
+		fake.fileExistsReturnsOnCall = make(map[int]struct {
+			result1 bool
+		})
+	}
+	fake.fileExistsReturnsOnCall[i] = struct {
+		result1 bool
 	}{result1}
 }
 
@@ -606,6 +678,8 @@ func (fake *FakeImpl) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.envDefaultMutex.RLock()
 	defer fake.envDefaultMutex.RUnlock()
+	fake.fileExistsMutex.RLock()
+	defer fake.fileExistsMutex.RUnlock()
 	fake.isImageSignedInternalMutex.RLock()
 	defer fake.isImageSignedInternalMutex.RUnlock()
 	fake.setenvMutex.RLock()


### PR DESCRIPTION
#### What type of PR is this?
/kind bug
/kind feature

#### What this PR does / why we need it:

This PR does two things:

First, it enables setting an identity token in the signer options enable doing keyless signing in environments that are not supported in the cosign identity providers (compute engine/GCP, github, spiffe or fixed file). The identity token can be defined in a new setting called `Options.IdentityToken`.

Secondly, since we are importing the cosign CLI, we need to ensure we have an OIDC identity token before attempting to do keyless signing. The reason is that we need to fail early if we don't have one or else the cosign CLI will attempt to ask the user  for one non interactively and fail,  as it will never get it:

```
Enter the verification code XXXX-XXXX in your browser at: https://oauth2.sigstore.dev/auth/device?user_code=XXX-XXXX
```

This PR modifies the signing library to ensure we have an identity token before calling the cosign methods. The token will be read from the new option and if not found there, the signer will attempt to call the cosign identity providers to get one. This last feature can be controlled via the `Options.EnableTokenProviders` so setting it to `false` and attempting to sign things will fail if no id token is provided in the options.

#### Which issue(s) this PR fixes:

Unblocks https://github.com/kubernetes-sigs/promo-tools/pull/501
Part of: https://github.com/kubernetes/release/issues/2383

#### Special notes for your reviewer:

/assign @cpanato @saschagrunert @xmudrii @palnabarun @PushkarJ 
/cc @kubernetes-sigs/release-engineering 

#### Does this PR introduce a user-facing change?

```release-note
- New `sign.Options` setting `IdentityToken` to pass the signer an OIDC identity token externally obtained.
- The signer will now read the identity token for keyless signing from the options and if not found, it will attempt to get one from the cosign identity providers. To disable this feature (eg to sign in air-gapped environments)  `Options.EnableTokenProviders` can be set to false
```
