### PR TITLE
Remove log from signer impl and add it to options

### DIFF
--- a/sign/impl.go
+++ b/sign/impl.go
@@ -33,9 +33,7 @@ import (
 	"sigs.k8s.io/release-utils/util"
 )
 
-type defaultImpl struct {
-	log *logrus.Logger
-}
+type defaultImpl struct{}
 
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 //counterfeiter:generate . impl
@@ -50,7 +48,7 @@ type impl interface {
 		recursive bool, attachment string) error
 	Setenv(string, string) error
 	EnvDefault(string, string) string
-	TokenFromProviders(context.Context) (string, error)
+	TokenFromProviders(context.Context, *logrus.Logger) (string, error)
 	FileExists(string) bool
 }
 
@@ -112,9 +110,9 @@ func (*defaultImpl) IsImageSignedInternal(
 
 // TokenFromProviders will try the cosign OIDC providers to get an
 // oidc token from them.
-func (di *defaultImpl) TokenFromProviders(ctx context.Context) (string, error) {
-	if !di.IdentityProvidersEnabled(ctx) {
-		di.log.Warn("No OIDC provider enabled. Token cannot be obtained autmatically.")
+func (d *defaultImpl) TokenFromProviders(ctx context.Context, logger *logrus.Logger) (string, error) {
+	if !d.IdentityProvidersEnabled(ctx) {
+		logger.Warn("No OIDC provider enabled. Token cannot be obtained autmatically.")
 		return "", nil
 	}
 

--- a/sign/impl_test.go
+++ b/sign/impl_test.go
@@ -21,7 +21,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -60,7 +59,7 @@ func TestFileExists(t *testing.T) {
 	require.NoError(t, err)
 	defer os.Remove(f.Name())
 	require.NoError(t, os.WriteFile(f.Name(), []byte("hey"), os.FileMode(0o644)))
-	sut := &defaultImpl{log: logrus.New()}
+	sut := &defaultImpl{}
 	require.True(t, sut.FileExists(f.Name()))
 	require.False(t, sut.FileExists(f.Name()+"a"))
 }

--- a/sign/options.go
+++ b/sign/options.go
@@ -17,6 +17,7 @@ limitations under the License.
 package sign
 
 import (
+	"context"
 	"errors"
 	"time"
 
@@ -27,6 +28,9 @@ import (
 
 // Options can be used to modify the behavior of the signer.
 type Options struct {
+	// Logger is the custom logger to be used for message printing.
+	Logger *logrus.Logger
+
 	// Verbose can be used to enable a higher log verbosity
 	Verbose bool
 
@@ -58,6 +62,7 @@ type Options struct {
 // Default returns a default Options instance.
 func Default() *Options {
 	return &Options{
+		Logger:               logrus.StandardLogger(),
 		Timeout:              3 * time.Minute,
 		PassFunc:             generate.GetPass,
 		EnableTokenProviders: true,
@@ -75,11 +80,14 @@ func (o *Options) verifySignOptions() error {
 	}
 
 	// Ensure that the private key file exists
-	i := defaultImpl{
-		log: logrus.New(),
-	}
+	i := defaultImpl{}
 	if o.PrivateKeyPath != "" && !i.FileExists(o.PrivateKeyPath) {
 		return errors.New("specified private key file not found")
 	}
 	return nil
+}
+
+// context creates a new context with the timeout set within the options.
+func (o *Options) context() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), o.Timeout)
 }

--- a/sign/signfakes/fake_impl.go
+++ b/sign/signfakes/fake_impl.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/sigstore/cosign/cmd/cosign/cli/options"
 	signa "github.com/sigstore/cosign/cmd/cosign/cli/sign"
+	"github.com/sirupsen/logrus"
 	"sigs.k8s.io/release-sdk/sign"
 )
 
@@ -99,10 +100,11 @@ type FakeImpl struct {
 	signImageInternalReturnsOnCall map[int]struct {
 		result1 error
 	}
-	TokenFromProvidersStub        func(context.Context) (string, error)
+	TokenFromProvidersStub        func(context.Context, *logrus.Logger) (string, error)
 	tokenFromProvidersMutex       sync.RWMutex
 	tokenFromProvidersArgsForCall []struct {
 		arg1 context.Context
+		arg2 *logrus.Logger
 	}
 	tokenFromProvidersReturns struct {
 		result1 string
@@ -473,18 +475,19 @@ func (fake *FakeImpl) SignImageInternalReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeImpl) TokenFromProviders(arg1 context.Context) (string, error) {
+func (fake *FakeImpl) TokenFromProviders(arg1 context.Context, arg2 *logrus.Logger) (string, error) {
 	fake.tokenFromProvidersMutex.Lock()
 	ret, specificReturn := fake.tokenFromProvidersReturnsOnCall[len(fake.tokenFromProvidersArgsForCall)]
 	fake.tokenFromProvidersArgsForCall = append(fake.tokenFromProvidersArgsForCall, struct {
 		arg1 context.Context
-	}{arg1})
+		arg2 *logrus.Logger
+	}{arg1, arg2})
 	stub := fake.TokenFromProvidersStub
 	fakeReturns := fake.tokenFromProvidersReturns
-	fake.recordInvocation("TokenFromProviders", []interface{}{arg1})
+	fake.recordInvocation("TokenFromProviders", []interface{}{arg1, arg2})
 	fake.tokenFromProvidersMutex.Unlock()
 	if stub != nil {
-		return stub(arg1)
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -498,17 +501,17 @@ func (fake *FakeImpl) TokenFromProvidersCallCount() int {
 	return len(fake.tokenFromProvidersArgsForCall)
 }
 
-func (fake *FakeImpl) TokenFromProvidersCalls(stub func(context.Context) (string, error)) {
+func (fake *FakeImpl) TokenFromProvidersCalls(stub func(context.Context, *logrus.Logger) (string, error)) {
 	fake.tokenFromProvidersMutex.Lock()
 	defer fake.tokenFromProvidersMutex.Unlock()
 	fake.TokenFromProvidersStub = stub
 }
 
-func (fake *FakeImpl) TokenFromProvidersArgsForCall(i int) context.Context {
+func (fake *FakeImpl) TokenFromProvidersArgsForCall(i int) (context.Context, *logrus.Logger) {
 	fake.tokenFromProvidersMutex.RLock()
 	defer fake.tokenFromProvidersMutex.RUnlock()
 	argsForCall := fake.tokenFromProvidersArgsForCall[i]
-	return argsForCall.arg1
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeImpl) TokenFromProvidersReturns(result1 string, result2 error) {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
We now feature a custom logger within the `Options` structure and remove
the logger from the `defaultImpl` by passing it around.

We also add a convenience method to the options to create a context
based on the internally provided timeout.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `Logger` to sign options. By default we initialize a new logger if `nil`.
```
