### PR TITLE
Make attaching image signature optional

### DIFF
--- a/sign/options.go
+++ b/sign/options.go
@@ -38,7 +38,12 @@ type Options struct {
 	// Defaults to 3 minutes
 	Timeout time.Duration
 
-	AllowInsecure         bool
+	AllowInsecure bool
+
+	// AttachSignature tells the signer to attach or not the new
+	// signature to its image
+	AttachSignature bool
+
 	OutputSignaturePath   string
 	OutputCertificatePath string
 	Annotations           map[string]interface{}
@@ -66,6 +71,7 @@ func Default() *Options {
 		Timeout:              3 * time.Minute,
 		PassFunc:             generate.GetPass,
 		EnableTokenProviders: true,
+		AttachSignature:      true,
 	}
 }
 

--- a/sign/sign.go
+++ b/sign/sign.go
@@ -133,7 +133,7 @@ func (s *Signer) SignImage(reference string) (*SignedObject, error) {
 	}
 
 	if err := s.impl.SignImageInternal(ctx, ko, regOpts,
-		s.options.Annotations, images, "", true, outputSignature,
+		s.options.Annotations, images, "", s.options.AttachSignature, outputSignature,
 		outputCertificate, "", true, false, "",
 	); err != nil {
 		return nil, errors.Wrapf(err, "sign reference: %s", reference)


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:

This commit introduces an option to control if signatures get
attached to images after signing. It may be the case that we
need to store the signature or attach it at a different time.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>


#### Which issue(s) this PR fixes:

Part of https://github.com/kubernetes/release/issues/2383

#### Special notes for your reviewer:

Most likely we will have to attach the signatures in the image promoter outside of cosign
as one identity signs and another promotes. So we need to make attaching it from the
signer optional to avoid an error when the signer is not authorized to push.

/assign @cpanato @saschagrunert
/cc @kubernetes-sigs/release-engineering 

#### Does this PR introduce a user-facing change?
```release-note
When signing a container image, attaching the signature by pushing it to the registry is now optional. 
```
