### PR TITLE
Dont verify remote image when not attaching

### DIFF
--- a/sign/sign.go
+++ b/sign/sign.go
@@ -139,6 +139,11 @@ func (s *Signer) SignImage(reference string) (*SignedObject, error) {
 		return nil, errors.Wrapf(err, "sign reference: %s", reference)
 	}
 
+	if !s.options.AttachSignature {
+		// TODO: https://github.com/kubernetes-sigs/release-sdk/issues/37
+		return &SignedObject{}, nil
+	}
+
 	object, err := s.impl.VerifyImageInternal(ctx, s.options.PublicKeyPath, images)
 	if err != nil {
 		return nil, errors.Wrapf(err, "verify reference: %s", images)


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

When signing an image without attaching the signature, do not attempt
to verify the remote reference as it will always fail.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>


#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

Returned `SignedObject` is still empty waiting for https://github.com/kubernetes-sigs/release-sdk/issues/37

/cc @kubernetes-sigs/release-engineering 

#### Does this PR introduce a user-facing change?
```release-note
Fixed a bug where image signing "failed" when trying to verify signed images that do not have their signatures attached
```
