### PR TITLE
Log on unsigned image verification

### DIFF
--- a/sign/sign.go
+++ b/sign/sign.go
@@ -180,6 +180,7 @@ func (s *Signer) VerifyImage(reference string) (*SignedObject, error) {
 	}
 
 	if !isSigned {
+		s.log().Infof("Skipping unsigned image: %s", reference)
 		return nil, nil
 	}
 


### PR DESCRIPTION

#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
To increase the verbosity we now log an info message if an unsigned images is skipped during its verification.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Logging an info message if an unsigned images is skipped during its verification.
```
