### PR TITLE
Switch to golang native error wrapping

### DIFF
--- a/gcli/gcli.go
+++ b/gcli/gcli.go
@@ -17,7 +17,7 @@ limitations under the License.
 package gcli
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
 
 	"sigs.k8s.io/release-utils/command"
 )
@@ -36,7 +36,7 @@ func PreCheck() error {
 		gsutilExecutable,
 	} {
 		if !command.Available(e) {
-			return errors.Errorf(
+			return fmt.Errorf(
 				"%s executable is not available in $PATH", e,
 			)
 		}
@@ -54,7 +54,7 @@ func GCloud(args ...string) error {
 func GCloudOutput(args ...string) (string, error) {
 	stream, err := command.New(GCloudExecutable, args...).RunSilentSuccessOutput()
 	if err != nil {
-		return "", errors.Wrapf(err, "executing %s", GCloudExecutable)
+		return "", fmt.Errorf("executing %s: %w", GCloudExecutable, err)
 	}
 	return stream.OutputTrimNL(), nil
 }
@@ -68,7 +68,7 @@ func GSUtil(args ...string) error {
 func GSUtilOutput(args ...string) (string, error) {
 	stream, err := command.New(gsutilExecutable, args...).RunSilentSuccessOutput()
 	if err != nil {
-		return "", errors.Wrapf(err, "executing %s", gsutilExecutable)
+		return "", fmt.Errorf("executing %s: %w", gsutilExecutable, err)
 	}
 	return stream.OutputTrimNL(), nil
 }

--- a/git/describe.go
+++ b/git/describe.go
@@ -17,9 +17,8 @@ limitations under the License.
 package git
 
 import (
+	"errors"
 	"fmt"
-
-	"github.com/pkg/errors"
 
 	"sigs.k8s.io/release-utils/command"
 )

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package git_test
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -28,7 +29,6 @@ import (
 
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing/object"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
 	"sigs.k8s.io/release-sdk/git"
@@ -84,14 +84,14 @@ func TestGetDefaultKubernetesRepoURLSuccess(t *testing.T) {
 func createTestRepository() (repoPath string, err error) {
 	repoPath, err = os.MkdirTemp("", "sigrelease-test-repo-*")
 	if err != nil {
-		return "", errors.Wrap(err, "creating a directory for test repository")
+		return "", fmt.Errorf("creating a directory for test repository: %w", err)
 	}
 	if err := os.Chdir(repoPath); err != nil {
-		return "", errors.Wrap(err, "cd'ing into test repository")
+		return "", fmt.Errorf("cd'ing into test repository: %w", err)
 	}
 	out, err := exec.Command("git", "init").Output()
 	if err != nil {
-		return "", errors.Wrapf(err, "initializing test repository: %s", out)
+		return "", fmt.Errorf("initializing test repository: %s: %w", out, err)
 	}
 	return repoPath, nil
 }

--- a/github/fork.go
+++ b/github/fork.go
@@ -17,7 +17,8 @@ limitations under the License.
 package github
 
 import (
-	"github.com/pkg/errors"
+	"fmt"
+
 	"github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/release-sdk/git"
@@ -38,7 +39,7 @@ func PrepareFork(branchName, upstreamOrg, upstreamRepo, myOrg, myRepo string) (r
 		upstreamOrg, upstreamRepo, false,
 	)
 	if err != nil {
-		return nil, errors.Wrapf(err, "cloning %s/%s", upstreamOrg, upstreamRepo)
+		return nil, fmt.Errorf("cloning %s/%s: %w", upstreamOrg, upstreamRepo, err)
 	}
 
 	// test if the fork remote is already existing
@@ -52,14 +53,14 @@ func PrepareFork(branchName, upstreamOrg, upstreamRepo, myOrg, myRepo string) (r
 		// add the user's fork as a remote
 		err = repo.AddRemote(UserForkName, myOrg, myRepo)
 		if err != nil {
-			return nil, errors.Wrap(err, "adding user's fork as remote repository")
+			return nil, fmt.Errorf("adding user's fork as remote repository: %w", err)
 		}
 	}
 
 	// checkout the new branch
 	err = repo.Checkout("-B", branchName)
 	if err != nil {
-		return nil, errors.Wrapf(err, "creating new branch %s", branchName)
+		return nil, fmt.Errorf("creating new branch %s: %w", branchName, err)
 	}
 
 	return repo, nil
@@ -75,16 +76,16 @@ func VerifyFork(branchName, forkOwner, forkRepo, parentOwner, parentRepo string)
 		forkOwner, forkRepo, parentOwner, parentRepo,
 	)
 	if err != nil {
-		return errors.Wrapf(
-			err, "while checking if repository is a fork of %s/%s",
-			parentOwner, parentRepo,
+		return fmt.Errorf(
+			"while checking if repository is a fork of %s/%s: %w",
+			parentOwner, parentRepo, err,
 		)
 	}
 
 	if !isRepo {
-		return errors.Errorf(
-			"cannot create PR, %s/%s is not a fork of %s/%s",
-			forkOwner, forkRepo, parentOwner, parentRepo,
+		return fmt.Errorf(
+			"cannot create PR, %s/%s is not a fork of %s/%s: %w",
+			forkOwner, forkRepo, parentOwner, parentRepo, err,
 		)
 	}
 
@@ -93,13 +94,13 @@ func VerifyFork(branchName, forkOwner, forkRepo, parentOwner, parentRepo string)
 		forkOwner, forkRepo, branchName,
 	)
 	if err != nil {
-		return errors.Wrap(err, "while checking if branch can be created")
+		return fmt.Errorf("while checking if branch can be created: %w", err)
 	}
 
 	if branchExists {
-		return errors.Errorf(
-			"a branch named %s already exists in %s/%s",
-			branchName, forkOwner, forkRepo,
+		return fmt.Errorf(
+			"a branch named %s already exists in %s/%s: %w",
+			branchName, forkOwner, forkRepo, err,
 		)
 	}
 	return nil

--- a/github/github.go
+++ b/github/github.go
@@ -18,6 +18,7 @@ package github
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -26,7 +27,6 @@ import (
 	"strings"
 
 	"github.com/google/go-github/v39/github"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 
@@ -338,7 +338,7 @@ func (g *githubClient) ListBranches(
 ) ([]*github.Branch, *github.Response, error) {
 	branches, response, err := g.Repositories.ListBranches(ctx, owner, repo, opt)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "fetching brnaches from repo")
+		return nil, nil, fmt.Errorf("fetching brnaches from repo: %w", err)
 	}
 
 	return branches, response, nil
@@ -369,7 +369,7 @@ func (g *githubClient) CreatePullRequest(
 
 	pr, _, err := g.PullRequests.Create(ctx, owner, repo, newPullRequest)
 	if err != nil {
-		return pr, errors.Wrap(err, "creating pull request")
+		return pr, fmt.Errorf("creating pull request: %w", err)
 	}
 
 	logrus.Infof("Successfully created PR #%d", pr.GetNumber())
@@ -382,7 +382,7 @@ func (g *githubClient) CreateIssue(
 	// Create the issue on github
 	issue, _, err := g.Issues.Create(ctx, owner, repo, req)
 	if err != nil {
-		return issue, errors.Wrap(err, "creating new issue")
+		return issue, fmt.Errorf("creating new issue: %w", err)
 	}
 
 	logrus.Infof("Successfully created issue #%d: %s", issue.GetNumber(), issue.GetTitle())
@@ -394,7 +394,7 @@ func (g *githubClient) GetRepository(
 ) (*github.Repository, *github.Response, error) {
 	pr, resp, err := g.Repositories.Get(ctx, owner, repo)
 	if err != nil {
-		return pr, resp, errors.Wrap(err, "getting repository")
+		return pr, resp, fmt.Errorf("getting repository: %w", err)
 	}
 
 	return pr, resp, nil
@@ -412,7 +412,7 @@ func (g *githubClient) UpdateReleasePage(
 	}
 
 	if err != nil {
-		return nil, errors.Wrap(err, "updating release pagin in github")
+		return nil, fmt.Errorf("updating release pagin in github: %w", err)
 	}
 
 	return release, nil
@@ -426,7 +426,7 @@ func (g *githubClient) UploadReleaseAsset(
 		ctx, owner, repo, releaseID, opts, file,
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "while uploading asset file")
+		return nil, fmt.Errorf("while uploading asset file: %w", err)
 	}
 
 	return asset, nil
@@ -436,7 +436,7 @@ func (g *githubClient) DeleteReleaseAsset(
 	ctx context.Context, owner string, repo string, assetID int64) error {
 	_, err := g.Repositories.DeleteReleaseAsset(ctx, owner, repo, assetID)
 	if err != nil {
-		return errors.Wrapf(err, "deleting asset %d", assetID)
+		return fmt.Errorf("deleting asset %d: %w", assetID, err)
 	}
 	return nil
 }
@@ -450,7 +450,7 @@ func (g *githubClient) ListReleaseAssets(
 	for {
 		moreAssets, r, err := g.Repositories.ListReleaseAssets(ctx, owner, repo, releaseID, options)
 		if err != nil {
-			return nil, errors.Wrap(err, "getting release assets from GitHub")
+			return nil, fmt.Errorf("getting release assets from GitHub: %w", err)
 		}
 		assets = append(assets, moreAssets...)
 		if r.NextPage == 0 {
@@ -519,7 +519,7 @@ func (g *GitHub) LatestGitHubTagsPerBranch() (TagsPerBranch, error) {
 			opts,
 		)
 		if err != nil {
-			return nil, errors.Wrap(err, "unable to retrieve GitHub tags")
+			return nil, fmt.Errorf("unable to retrieve GitHub tags: %w", err)
 		}
 		allTags = append(allTags, tags...)
 		if resp.NextPage == 0 {
@@ -575,7 +575,7 @@ func (g *GitHub) Releases(owner, repo string, includePrereleases bool) ([]*githu
 		context.Background(), owner, repo, nil,
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "unable to retrieve GitHub releases")
+		return nil, fmt.Errorf("unable to retrieve GitHub releases: %w", err)
 	}
 
 	releases := []*github.RepositoryRelease{}
@@ -598,7 +598,7 @@ func (g *GitHub) Releases(owner, repo string, includePrereleases bool) ([]*githu
 func (g *GitHub) GetReleaseTags(owner, repo string, includePrereleases bool) ([]string, error) {
 	releases, err := g.Releases(owner, repo, includePrereleases)
 	if err != nil {
-		return nil, errors.Wrap(err, "getting releases")
+		return nil, fmt.Errorf("getting releases: %w", err)
 	}
 
 	releaseTags := []string{}
@@ -618,7 +618,7 @@ func (g *GitHub) DownloadReleaseAssets(owner, repo string, releaseTags []string,
 		for _, tag := range releaseTags {
 			release, _, err := g.client.GetReleaseByTag(context.Background(), owner, repo, tag)
 			if err != nil {
-				return errors.Wrapf(err, "getting release from tag %s", tag)
+				return fmt.Errorf("getting release from tag %s: %w", tag, err)
 			}
 			releases = append(releases, release)
 		}
@@ -641,12 +641,12 @@ func (g *GitHub) DownloadReleaseAssets(owner, repo string, releaseTags []string,
 
 			releaseDir := filepath.Join(outputDir, owner, repo, releaseTag)
 			if err := os.MkdirAll(releaseDir, os.FileMode(0o775)); err != nil {
-				return errors.Wrap(err, "creating output directory for release assets")
+				return fmt.Errorf("creating output directory for release assets: %w", err)
 			}
 
 			logrus.WithField("release", releaseTag).Infof("Writing assets to %s", releaseDir)
 			if err := g.downloadAssetsParallel(assets, owner, repo, releaseDir); err != nil {
-				return errors.Wrapf(err, "downloading assets for %s", releaseTag)
+				return fmt.Errorf("downloading assets for %s", releaseTag)
 			}
 			return nil
 		})
@@ -658,7 +658,7 @@ func (g *GitHub) DownloadReleaseAssets(owner, repo string, releaseTags []string,
 				finalErr = err
 				continue
 			}
-			finalErr = errors.Wrap(finalErr, err.Error())
+			finalErr = fmt.Errorf("%v: %w", finalErr, err)
 		}
 	}
 	return finalErr
@@ -676,19 +676,19 @@ func (g *GitHub) downloadAssetsParallel(assets []*github.ReleaseAsset, owner, re
 			logrus.Infof("GitHub asset ID: %v, download URL: %s", *asset.ID, *asset.BrowserDownloadURL)
 			assetBody, _, err := g.client.DownloadReleaseAsset(context.Background(), owner, repo, asset.GetID())
 			if err != nil {
-				return errors.Wrap(err, "downloading release assets")
+				return fmt.Errorf("downloading release assets: %w", err)
 			}
 
 			absFile := filepath.Join(releaseDir, asset.GetName())
 			defer assetBody.Close()
 			assetFile, err := os.Create(absFile)
 			if err != nil {
-				return errors.Wrap(err, "creating release asset file")
+				return fmt.Errorf("creating release asset file: %w", err)
 			}
 
 			defer assetFile.Close()
 			if _, err := io.Copy(assetFile, assetBody); err != nil {
-				return errors.Wrap(err, "copying release asset to file")
+				return fmt.Errorf("copying release asset to file: %w", err)
 			}
 			return nil
 		})
@@ -700,7 +700,7 @@ func (g *GitHub) downloadAssetsParallel(assets []*github.ReleaseAsset, owner, re
 				finalErr = err
 				continue
 			}
-			finalErr = errors.Wrap(finalErr, err.Error())
+			finalErr = fmt.Errorf("%v: %w", finalErr, err)
 		}
 	}
 	return finalErr
@@ -727,7 +727,7 @@ func (g *GitHub) UploadReleaseAsset(
 
 	f, err := os.Open(fileName)
 	if err != nil {
-		return nil, errors.Wrap(err, "opening the asset file for reading")
+		return nil, fmt.Errorf("opening the asset file for reading: %w", err)
 	}
 
 	// Only the first 512 bytes are used to sniff the content type.
@@ -735,12 +735,12 @@ func (g *GitHub) UploadReleaseAsset(
 
 	_, err = f.Read(buffer)
 	if err != nil {
-		return nil, errors.Wrap(err, "reading file to determine mimetype")
+		return nil, fmt.Errorf("reading file to determine mimetype: %w", err)
 	}
 	// Reset the pointer to reuse the filehandle
 	_, err = f.Seek(0, 0)
 	if err != nil {
-		return nil, errors.Wrap(err, "rewinding the asset filepointer")
+		return nil, fmt.Errorf("rewinding the asset filepointer: %w", err)
 	}
 
 	contentType := http.DetectContentType(buffer)
@@ -756,7 +756,7 @@ func (g *GitHub) UploadReleaseAsset(
 		context.Background(), owner, repo, releaseID, uopts, f,
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "uploading asset file to release")
+		return nil, fmt.Errorf("uploading asset file to release: %w", err)
 	}
 
 	return asset, nil
@@ -823,7 +823,7 @@ func (g *GitHub) GetMilestone(owner, repo, title string) (
 		mstones, resp, err := g.Client().ListMilestones(
 			context.Background(), owner, repo, opts)
 		if err != nil {
-			return nil, exists, errors.Wrap(err, "listing repository milestones")
+			return nil, exists, fmt.Errorf("listing repository milestones: %w", err)
 		}
 		for _, ms = range mstones {
 			if ms.GetTitle() == title {
@@ -863,7 +863,7 @@ func (g *GitHub) ListBranches(
 	for {
 		moreBranches, r, err := g.Client().ListBranches(context.Background(), owner, repo, options)
 		if err != nil {
-			return branches, errors.Wrap(err, "getting branches from client")
+			return branches, fmt.Errorf("getting branches from client: %w", err)
 		}
 		branches = append(branches, moreBranches...)
 		if r.NextPage == 0 {
@@ -881,7 +881,7 @@ func (g *GitHub) RepoIsForkOf(
 ) (bool, error) {
 	repository, _, err := g.Client().GetRepository(context.Background(), forkOwner, forkRepo)
 	if err != nil {
-		return false, errors.Wrap(err, "checking if repository is a fork")
+		return false, fmt.Errorf("checking if repository is a fork: %w", err)
 	}
 
 	// First, repo has to be an actual fork
@@ -906,7 +906,7 @@ func (g *GitHub) BranchExists(
 ) (isBranch bool, err error) {
 	branches, err := g.ListBranches(owner, repo)
 	if err != nil {
-		return false, errors.Wrap(err, "while listing repository branches")
+		return false, fmt.Errorf("while listing repository branches: %w", err)
 	}
 
 	for _, branch := range branches {
@@ -945,7 +945,7 @@ func (g *GitHub) UpdateReleasePage(
 	)
 
 	if err != nil {
-		return nil, errors.Wrap(err, "updating the release page")
+		return nil, fmt.Errorf("updating the release page: %w", err)
 	}
 
 	return release, nil
@@ -953,9 +953,12 @@ func (g *GitHub) UpdateReleasePage(
 
 // DeleteReleaseAsset deletes an asset from a release
 func (g *GitHub) DeleteReleaseAsset(owner, repo string, assetID int64) error {
-	return errors.Wrap(g.Client().DeleteReleaseAsset(
+	if err := g.Client().DeleteReleaseAsset(
 		context.Background(), owner, repo, assetID,
-	), "deleting asset from release")
+	); err != nil {
+		return fmt.Errorf("deleting asset from release: %w", err)
+	}
+	return nil
 }
 
 // ListReleaseAssets gets the assets uploaded to a GitHub release
@@ -967,7 +970,7 @@ func (g *GitHub) ListReleaseAssets(
 		&github.ListOptions{PerPage: g.Options().GetItemsPerPage()},
 	)
 	if err != nil {
-		return nil, errors.Wrap(err, "getting release assets")
+		return nil, fmt.Errorf("getting release assets: %w", err)
 	}
 	return assets, nil
 }
@@ -980,7 +983,7 @@ func (g *GitHub) TagExists(owner, repo, tag string) (exists bool, err error) {
 			context.Background(), owner, repo, options,
 		)
 		if err != nil {
-			return exists, errors.Wrap(err, "listing repository tags")
+			return exists, fmt.Errorf("listing repository tags: %w", err)
 		}
 
 		// List all tags returned and check if the one we're looking for exists
@@ -1006,7 +1009,7 @@ func (g *GitHub) ListTags(owner, repo string) ([]*github.RepositoryTag, error) {
 			context.Background(), owner, repo, options,
 		)
 		if err != nil {
-			return tags, errors.Wrap(err, "listing repository tags")
+			return tags, fmt.Errorf("listing repository tags: %w", err)
 		}
 
 		tags = append(tags, repoTags...)

--- a/github/record.go
+++ b/github/record.go
@@ -19,6 +19,7 @@ package github
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -26,7 +27,6 @@ import (
 	"sync"
 
 	"github.com/google/go-github/v39/github"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/google/go-github/v39 v39.1.0
 	github.com/magefile/mage v1.11.0
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.4.1
-	github.com/pkg/errors v0.9.1
 	github.com/sigstore/cosign v1.5.2
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.0
@@ -194,6 +193,7 @@ require (
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.11.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect

--- a/object/gcs.go
+++ b/object/gcs.go
@@ -17,11 +17,12 @@ limitations under the License.
 package object
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/release-sdk/gcli"
@@ -107,13 +108,12 @@ var (
 // CopyToRemote copies a local directory to the specified GCS path
 func (g *GCS) CopyToRemote(src, gcsPath string) error {
 	logrus.Infof("Copying %s to GCS (%s)", src, gcsPath)
-	gcsPath, gcsPathErr := g.NormalizePath(gcsPath)
-	if gcsPathErr != nil {
-		return errors.Wrap(gcsPathErr, "normalize GCS path")
+	gcsPath, err := g.NormalizePath(gcsPath)
+	if err != nil {
+		return fmt.Errorf("normalize GCS path: %w", err)
 	}
 
-	_, err := os.Stat(src)
-	if err != nil {
+	if _, err := os.Stat(src); err != nil {
 		logrus.Info("Unable to get local source directory info")
 
 		if g.allowMissing {
@@ -130,9 +130,9 @@ func (g *GCS) CopyToRemote(src, gcsPath string) error {
 // CopyToLocal copies a GCS path to the specified local directory
 func (g *GCS) CopyToLocal(gcsPath, dst string) error {
 	logrus.Infof("Copying GCS (%s) to %s", gcsPath, dst)
-	gcsPath, gcsPathErr := g.NormalizePath(gcsPath)
-	if gcsPathErr != nil {
-		return errors.Wrap(gcsPathErr, "normalize GCS path")
+	gcsPath, err := g.NormalizePath(gcsPath)
+	if err != nil {
+		return fmt.Errorf("normalize GCS path: %w", err)
 	}
 
 	return g.bucketCopy(gcsPath, dst)
@@ -142,14 +142,14 @@ func (g *GCS) CopyToLocal(gcsPath, dst string) error {
 func (g *GCS) CopyBucketToBucket(src, dst string) error {
 	logrus.Infof("Copying %s to %s", src, dst)
 
-	src, srcErr := g.NormalizePath(src)
-	if srcErr != nil {
-		return errors.Wrap(srcErr, "normalize GCS path")
+	src, err := g.NormalizePath(src)
+	if err != nil {
+		return fmt.Errorf("normalize GCS path: %w", err)
 	}
 
-	dst, dstErr := g.NormalizePath(dst)
-	if dstErr != nil {
-		return errors.Wrap(dstErr, "normalize GCS path")
+	dst, err = g.NormalizePath(dst)
+	if err != nil {
+		return fmt.Errorf("normalize GCS path: %w", err)
 	}
 
 	return g.bucketCopy(src, dst)
@@ -176,7 +176,7 @@ func (g *GCS) bucketCopy(src, dst string) error {
 	args = append(args, src, dst)
 
 	if err := gcli.GSUtil(args...); err != nil {
-		return errors.Wrap(err, "gcs copy")
+		return fmt.Errorf("gcs copy: %w", err)
 	}
 
 	return nil
@@ -197,7 +197,7 @@ func (g *GCS) GetReleasePath(
 		fast,
 	)
 	if err != nil {
-		return "", errors.Wrap(err, "normalize GCS path")
+		return "", fmt.Errorf("normalize GCS path: %w", err)
 	}
 
 	logrus.Infof("Release path is %s", gcsPath)
@@ -218,7 +218,7 @@ func (g *GCS) GetMarkerPath(
 		false,
 	)
 	if err != nil {
-		return "", errors.Wrap(err, "normalize GCS path")
+		return "", fmt.Errorf("normalize GCS path: %w", err)
 	}
 
 	logrus.Infof("Version marker path is %s", gcsPath)
@@ -356,16 +356,18 @@ func (g *GCS) IsPathNormalized(gcsPath string) bool {
 // function has to ensure that the provided paths are prefixed with gs:// if
 // necessary (see `NormalizePath()`).
 func (g *GCS) RsyncRecursive(src, dst string) error {
-	return errors.Wrap(
-		gcli.GSUtil(concurrentFlag, "rsync", recursiveFlag, src, dst),
-		"running gsutil rsync",
-	)
+	if err := gcli.GSUtil(
+		concurrentFlag, "rsync", recursiveFlag, src, dst,
+	); err != nil {
+		return fmt.Errorf("running gsutil rsync: %w", err)
+	}
+	return nil
 }
 
 // PathExists returns true if the specified GCS path exists.
 func (g *GCS) PathExists(gcsPath string) (bool, error) {
 	if !g.IsPathNormalized(gcsPath) {
-		return false, errors.Errorf(
+		return false, fmt.Errorf(
 			"cannot run `gsutil ls` GCS path does not begin with `%s`",
 			GcsPrefix,
 		)
@@ -393,7 +395,7 @@ func (g *GCS) PathExists(gcsPath string) (bool, error) {
 func (g *GCS) DeletePath(path string) error {
 	path, err := g.NormalizePath(path)
 	if err != nil {
-		return errors.Wrap(err, "normalizing GCS path")
+		return fmt.Errorf("normalizing GCS path: %w", err)
 	}
 
 	// Build the command arguments
@@ -415,7 +417,7 @@ func (g *GCS) DeletePath(path string) error {
 
 	// Call gsutil to remove the path
 	if err = gcli.GSUtil(args...); err != nil {
-		return errors.Wrap(err, "calling gsutil to remove path")
+		return fmt.Errorf("calling gsutil to remove path: %w", err)
 	}
 
 	return nil

--- a/sign/impl.go
+++ b/sign/impl.go
@@ -18,10 +18,10 @@ package sign
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/google/go-containerregistry/pkg/name"
-	"github.com/pkg/errors"
 	"github.com/sigstore/cosign/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/cmd/cosign/cli/sign"
 	"github.com/sigstore/cosign/cmd/cosign/cli/verify"
@@ -83,8 +83,7 @@ func (*defaultImpl) SignFileInternal(ctx context.Context, ko sign.KeyOpts, regOp
 	// Ignoring the signature return value for now as we are setting the outputSignature path and to keep an consistent impl API
 	// Setting timeout as 0 is acceptable here because SignBlobCmd uses the passed context
 	_, err := sign.SignBlobCmd(ctx, ko, regOpts, payloadPath, b64, outputSignature, outputCertificate, 0)
-
-	return errors.Wrapf(err, "signing file path: %v", payloadPath)
+	return err
 }
 
 func (*defaultImpl) Setenv(key, value string) error {
@@ -105,7 +104,7 @@ func (d *defaultImpl) TokenFromProviders(ctx context.Context, logger *logrus.Log
 
 	tok, err := providers.Provide(ctx, "sigstore")
 	if err != nil {
-		return "", errors.Wrap(err, "fetching oidc token from environment")
+		return "", fmt.Errorf("fetching oidc token from environment: %w", err)
 	}
 	return tok, nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This removes the direct `github.com/pkg/errors` dependency while using the native golang error wrapping.

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
Removed direct `github.com/pkg/errors` dependency by using golang native error wrapping.
```