### PR TITLE
Retry verification if it fails after signing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.7.1
 	golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a
+	k8s.io/apimachinery v0.23.5
 	sigs.k8s.io/release-utils v0.6.1-0.20220405215325-d4a2a2f0e8fd
 )
 
@@ -290,7 +291,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/api v0.23.5 // indirect
-	k8s.io/apimachinery v0.23.5 // indirect
 	k8s.io/client-go v0.23.5 // indirect
 	k8s.io/klog/v2 v2.60.1-0.20220317184644-43cc75f9ae89 // indirect
 	k8s.io/kube-openapi v0.0.0-20220124234850-424119656bbf // indirect

--- a/sign/options.go
+++ b/sign/options.go
@@ -63,6 +63,10 @@ type Options struct {
 	// is provided (i.e. it's not used for keyless signing).
 	// Defaults to a function that reads from stdin and asks for confirmation
 	PassFunc cosign.PassFunc
+
+	// MaxRetries indicates the number of times to retry operations
+	// when transient failures occur
+	MaxRetries int
 }
 
 // Default returns a default Options instance.
@@ -73,6 +77,7 @@ func Default() *Options {
 		PassFunc:             generate.GetPass,
 		EnableTokenProviders: true,
 		AttachSignature:      true,
+		MaxRetries:           3,
 	}
 }
 

--- a/sign/options.go
+++ b/sign/options.go
@@ -66,7 +66,7 @@ type Options struct {
 
 	// MaxRetries indicates the number of times to retry operations
 	// when transient failures occur
-	MaxRetries int
+	MaxRetries uint
 }
 
 // Default returns a default Options instance.

--- a/sign/sign.go
+++ b/sign/sign.go
@@ -140,7 +140,7 @@ func (s *Signer) SignImage(reference string) (object *SignedObject, err error) {
 	waitErr := wait.ExponentialBackoff(wait.Backoff{
 		Duration: 500 * time.Millisecond,
 		Factor:   1.5,
-		Steps:    s.options.MaxRetries,
+		Steps:    int(s.options.MaxRetries),
 	}, func() (bool, error) {
 		object, err = s.VerifyImage(images[0])
 		if err != nil {


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

This commit adds retries to the signing package. When signing an image, we will now retry and wait to account for eventual consistency in the registry.

Signed-off-by: Adolfo García Veytia (Puerco) <adolfo.garcia@uservers.net>


#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes-sigs/promo-tools/issues/536


#### Special notes for your reviewer:

/assign @cpanato @justaugustus 
/cc @kubernetes-sigs/release-engineering 

#### Does this PR introduce a user-facing change?


```release-note
The signer object will now wait and retry if validating a signature fails after signing. The number of retries can be controlled with a new `MaxRetries` option.
```
