### PR TITLE
GitHub replay `ListTags` to return data instead of empty slice

### DIFF
--- a/github/replay.go
+++ b/github/replay.go
@@ -190,7 +190,7 @@ func (c *githubNotesReplayClient) ListTags(
 		return nil, nil, err
 	}
 	result := []*github.RepositoryTag{}
-	record := apiRecord{Result: result}
+	record := apiRecord{Result: &result}
 	if err := json.Unmarshal(data, &record); err != nil {
 		return nil, nil, err
 	}

--- a/github/replay_test.go
+++ b/github/replay_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Kubernetes Authors.
+Copyright 2022 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/github/replay_test.go
+++ b/github/replay_test.go
@@ -29,7 +29,5 @@ func TestReplayListTags(t *testing.T) {
 	replayer := github.NewReplayer(testDataDir)
 	tags, _, err := replayer.ListTags(context.Background(), "", "", nil)
 	require.Nil(t, err)
-	if len(tags) != 19 {
-		t.Fatalf("expected tags to be 19, but received %d", len(tags))
-	}
+	require.Len(t, tags, 19)
 }

--- a/github/replay_test.go
+++ b/github/replay_test.go
@@ -28,9 +28,7 @@ const testDataDir = "testdata"
 func TestReplayListTags(t *testing.T) {
 	replayer := github.NewReplayer(testDataDir)
 	tags, _, err := replayer.ListTags(context.Background(), "", "", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.Nil(t, err)
 	if len(tags) != 19 {
 		t.Fatalf("expected tags to be 19, but received %d", len(tags))
 	}

--- a/github/replay_test.go
+++ b/github/replay_test.go
@@ -31,7 +31,7 @@ func TestReplayListTags(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(tags) == 0 {
-		t.Fatal("expected tags to be non-zero, but received empty slice")
+	if len(tags) != 19 {
+		t.Fatalf("expected tags to be 19, but received %d", len(tags))
 	}
 }

--- a/github/replay_test.go
+++ b/github/replay_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package github_test
+
+import (
+	"context"
+	"testing"
+
+	"sigs.k8s.io/release-sdk/github"
+)
+
+const testDataDir = "testdata"
+
+func TestReplayListTags(t *testing.T) {
+	replayer := github.NewReplayer(testDataDir)
+	tags, _, err := replayer.ListTags(context.Background(), "", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tags) == 0 {
+		t.Fatal("expected tags to be non-zero, but received empty slice")
+	}
+}

--- a/github/replay_test.go
+++ b/github/replay_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/release-sdk/github"
 )
 

--- a/github/testdata/ListTags-0.json
+++ b/github/testdata/ListTags-0.json
@@ -1,0 +1,176 @@
+{
+ "Result": [
+  {
+   "name": "v1.18.0-alpha.2",
+   "commit": {
+    "sha": "a7b4459cd1cf89420e2370ae5d067fc5ad6629ba",
+    "url": "https://api.github.com/repos/kubernetes/kubernetes/commits/a7b4459cd1cf89420e2370ae5d067fc5ad6629ba"
+   },
+   "zipball_url": "https://api.github.com/repos/kubernetes/kubernetes/zipball/refs/tags/v1.18.0-alpha.2",
+   "tarball_url": "https://api.github.com/repos/kubernetes/kubernetes/tarball/refs/tags/v1.18.0-alpha.2"
+  },
+  {
+   "name": "v1.18.0-alpha.1",
+   "commit": {
+    "sha": "ac4079a5cc22ced66c868f6fd26f8e2497765e51",
+    "url": "https://api.github.com/repos/kubernetes/kubernetes/commits/ac4079a5cc22ced66c868f6fd26f8e2497765e51"
+   },
+   "zipball_url": "https://api.github.com/repos/kubernetes/kubernetes/zipball/refs/tags/v1.18.0-alpha.1",
+   "tarball_url": "https://api.github.com/repos/kubernetes/kubernetes/tarball/refs/tags/v1.18.0-alpha.1"
+  },
+  {
+   "name": "v1.18.0-alpha.0",
+   "commit": {
+    "sha": "9731b51d2369f10e511d02275327bc0e63c5902c",
+    "url": "https://api.github.com/repos/kubernetes/kubernetes/commits/9731b51d2369f10e511d02275327bc0e63c5902c"
+   },
+   "zipball_url": "https://api.github.com/repos/kubernetes/kubernetes/zipball/refs/tags/v1.18.0-alpha.0",
+   "tarball_url": "https://api.github.com/repos/kubernetes/kubernetes/tarball/refs/tags/v1.18.0-alpha.0"
+  },
+  {
+   "name": "v1.17.18-rc.0",
+   "commit": {
+    "sha": "dc7672e14f60eb7f28bedaf0bd4ee3cd2c88e5a2",
+    "url": "https://api.github.com/repos/kubernetes/kubernetes/commits/dc7672e14f60eb7f28bedaf0bd4ee3cd2c88e5a2"
+   },
+   "zipball_url": "https://api.github.com/repos/kubernetes/kubernetes/zipball/refs/tags/v1.17.18-rc.0",
+   "tarball_url": "https://api.github.com/repos/kubernetes/kubernetes/tarball/refs/tags/v1.17.18-rc.0"
+  },
+  {
+   "name": "v1.17.17",
+   "commit": {
+    "sha": "f3abc15296f3a3f54e4ee42e830c61047b13895f",
+    "url": "https://api.github.com/repos/kubernetes/kubernetes/commits/f3abc15296f3a3f54e4ee42e830c61047b13895f"
+   },
+   "zipball_url": "https://api.github.com/repos/kubernetes/kubernetes/zipball/refs/tags/v1.17.17",
+   "tarball_url": "https://api.github.com/repos/kubernetes/kubernetes/tarball/refs/tags/v1.17.17"
+  },
+  {
+   "name": "v1.17.17-rc.0",
+   "commit": {
+    "sha": "cb85da1f320014451b011c418856905e2699df17",
+    "url": "https://api.github.com/repos/kubernetes/kubernetes/commits/cb85da1f320014451b011c418856905e2699df17"
+   },
+   "zipball_url": "https://api.github.com/repos/kubernetes/kubernetes/zipball/refs/tags/v1.17.17-rc.0",
+   "tarball_url": "https://api.github.com/repos/kubernetes/kubernetes/tarball/refs/tags/v1.17.17-rc.0"
+  },
+  {
+   "name": "v1.17.16",
+   "commit": {
+    "sha": "d88fadbd65c5e8bde22630d251766a634c7613b0",
+    "url": "https://api.github.com/repos/kubernetes/kubernetes/commits/d88fadbd65c5e8bde22630d251766a634c7613b0"
+   },
+   "zipball_url": "https://api.github.com/repos/kubernetes/kubernetes/zipball/refs/tags/v1.17.16",
+   "tarball_url": "https://api.github.com/repos/kubernetes/kubernetes/tarball/refs/tags/v1.17.16"
+  },
+  {
+   "name": "v1.17.16-rc.1",
+   "commit": {
+    "sha": "e91de4184517b1ab8c21d00e146865485fe228bb",
+    "url": "https://api.github.com/repos/kubernetes/kubernetes/commits/e91de4184517b1ab8c21d00e146865485fe228bb"
+   },
+   "zipball_url": "https://api.github.com/repos/kubernetes/kubernetes/zipball/refs/tags/v1.17.16-rc.1",
+   "tarball_url": "https://api.github.com/repos/kubernetes/kubernetes/tarball/refs/tags/v1.17.16-rc.1"
+  },
+  {
+   "name": "v1.17.16-rc.0",
+   "commit": {
+    "sha": "737e2c461a2999fa242d39e77b9252d0eee7167e",
+    "url": "https://api.github.com/repos/kubernetes/kubernetes/commits/737e2c461a2999fa242d39e77b9252d0eee7167e"
+   },
+   "zipball_url": "https://api.github.com/repos/kubernetes/kubernetes/zipball/refs/tags/v1.17.16-rc.0",
+   "tarball_url": "https://api.github.com/repos/kubernetes/kubernetes/tarball/refs/tags/v1.17.16-rc.0"
+  },
+  {
+   "name": "v1.17.15",
+   "commit": {
+    "sha": "737e2c461a2999fa242d39e77b9252d0eee7167e",
+    "url": "https://api.github.com/repos/kubernetes/kubernetes/commits/737e2c461a2999fa242d39e77b9252d0eee7167e"
+   },
+   "zipball_url": "https://api.github.com/repos/kubernetes/kubernetes/zipball/refs/tags/v1.17.15",
+   "tarball_url": "https://api.github.com/repos/kubernetes/kubernetes/tarball/refs/tags/v1.17.15"
+  },
+  {
+   "name": "v1.17.15-rc.0",
+   "commit": {
+    "sha": "3f6ee50ba0ed071a023c939276de16280c0837a6",
+    "url": "https://api.github.com/repos/kubernetes/kubernetes/commits/3f6ee50ba0ed071a023c939276de16280c0837a6"
+   },
+   "zipball_url": "https://api.github.com/repos/kubernetes/kubernetes/zipball/refs/tags/v1.17.15-rc.0",
+   "tarball_url": "https://api.github.com/repos/kubernetes/kubernetes/tarball/refs/tags/v1.17.15-rc.0"
+  },
+  {
+   "name": "v1.17.14",
+   "commit": {
+    "sha": "f238f5142728be4033c37aa0ad69bf806090beae",
+    "url": "https://api.github.com/repos/kubernetes/kubernetes/commits/f238f5142728be4033c37aa0ad69bf806090beae"
+   },
+   "zipball_url": "https://api.github.com/repos/kubernetes/kubernetes/zipball/refs/tags/v1.17.14",
+   "tarball_url": "https://api.github.com/repos/kubernetes/kubernetes/tarball/refs/tags/v1.17.14"
+  },
+  {
+   "name": "v1.17.14-rc.0",
+   "commit": {
+    "sha": "74c9244980316a247f9f1bd64bca7a9a79773939",
+    "url": "https://api.github.com/repos/kubernetes/kubernetes/commits/74c9244980316a247f9f1bd64bca7a9a79773939"
+   },
+   "zipball_url": "https://api.github.com/repos/kubernetes/kubernetes/zipball/refs/tags/v1.17.14-rc.0",
+   "tarball_url": "https://api.github.com/repos/kubernetes/kubernetes/tarball/refs/tags/v1.17.14-rc.0"
+  },
+  {
+   "name": "v1.17.13",
+   "commit": {
+    "sha": "30d651da517185653e34e7ab99a792be6a3d9495",
+    "url": "https://api.github.com/repos/kubernetes/kubernetes/commits/30d651da517185653e34e7ab99a792be6a3d9495"
+   },
+   "zipball_url": "https://api.github.com/repos/kubernetes/kubernetes/zipball/refs/tags/v1.17.13",
+   "tarball_url": "https://api.github.com/repos/kubernetes/kubernetes/tarball/refs/tags/v1.17.13"
+  },
+  {
+   "name": "v1.17.13-rc.0",
+   "commit": {
+    "sha": "d936ab78a5f04fa2e11442cf81c369a705bfc710",
+    "url": "https://api.github.com/repos/kubernetes/kubernetes/commits/d936ab78a5f04fa2e11442cf81c369a705bfc710"
+   },
+   "zipball_url": "https://api.github.com/repos/kubernetes/kubernetes/zipball/refs/tags/v1.17.13-rc.0",
+   "tarball_url": "https://api.github.com/repos/kubernetes/kubernetes/tarball/refs/tags/v1.17.13-rc.0"
+  },
+  {
+   "name": "v1.17.12",
+   "commit": {
+    "sha": "5ec472285121eb6c451e515bc0a7201413872fa3",
+    "url": "https://api.github.com/repos/kubernetes/kubernetes/commits/5ec472285121eb6c451e515bc0a7201413872fa3"
+   },
+   "zipball_url": "https://api.github.com/repos/kubernetes/kubernetes/zipball/refs/tags/v1.17.12",
+   "tarball_url": "https://api.github.com/repos/kubernetes/kubernetes/tarball/refs/tags/v1.17.12"
+  },
+  {
+   "name": "v1.17.12-rc.0",
+   "commit": {
+    "sha": "b61310629c190cd6f4beea83c05001d7b404d16c",
+    "url": "https://api.github.com/repos/kubernetes/kubernetes/commits/b61310629c190cd6f4beea83c05001d7b404d16c"
+   },
+   "zipball_url": "https://api.github.com/repos/kubernetes/kubernetes/zipball/refs/tags/v1.17.12-rc.0",
+   "tarball_url": "https://api.github.com/repos/kubernetes/kubernetes/tarball/refs/tags/v1.17.12-rc.0"
+  },
+  {
+   "name": "v1.17.11",
+   "commit": {
+    "sha": "ea5f00d93211b7c80247bf607cfa422ad6fb5347",
+    "url": "https://api.github.com/repos/kubernetes/kubernetes/commits/ea5f00d93211b7c80247bf607cfa422ad6fb5347"
+   },
+   "zipball_url": "https://api.github.com/repos/kubernetes/kubernetes/zipball/refs/tags/v1.17.11",
+   "tarball_url": "https://api.github.com/repos/kubernetes/kubernetes/tarball/refs/tags/v1.17.11"
+  },
+  {
+   "name": "v1.17.11-rc.1",
+   "commit": {
+    "sha": "7ad2d99ef7f65ebf271f19ef75238a75bc77d806",
+    "url": "https://api.github.com/repos/kubernetes/kubernetes/commits/7ad2d99ef7f65ebf271f19ef75238a75bc77d806"
+   },
+   "zipball_url": "https://api.github.com/repos/kubernetes/kubernetes/zipball/refs/tags/v1.17.11-rc.1",
+   "tarball_url": "https://api.github.com/repos/kubernetes/kubernetes/tarball/refs/tags/v1.17.11-rc.1"
+  }
+ ],
+ "LastPage": 18
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

Fixes bug on GitHub replayer to return recorded data instead of empty slice.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

Fixes #59 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
GitHub replay `ListTags` to return data instead of empty slice.
```
