### PR TITLE
Fix error message if branch already exists in fork

### DIFF
--- a/github/fork.go
+++ b/github/fork.go
@@ -99,8 +99,8 @@ func VerifyFork(branchName, forkOwner, forkRepo, parentOwner, parentRepo string)
 
 	if branchExists {
 		return fmt.Errorf(
-			"a branch named %s already exists in %s/%s: %w",
-			branchName, forkOwner, forkRepo, err,
+			"a branch named %s already exists in %s/%s",
+			branchName, forkOwner, forkRepo,
 		)
 	}
 	return nil


### PR DESCRIPTION

#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
Fixing the nil error to be printed to the user.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed invalid error message if branch already exists in GitHub fork.
```
