### PR TITLE
Pass `nil` on integration test key generation

### DIFF
--- a/sign/options.go
+++ b/sign/options.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/sigstore/cosign/cmd/cosign/cli/generate"
 	"github.com/sigstore/cosign/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/pkg/cosign"
 	"github.com/sirupsen/logrus"
@@ -61,7 +60,7 @@ type Options struct {
 	// PassFunc is a function that returns a slice of bytes that will be used
 	// as a password for decrypting the cosign key. It is used only if PrivateKeyPath
 	// is provided (i.e. it's not used for keyless signing).
-	// Defaults to a function that reads from stdin and asks for confirmation
+	// Defaults to nil, which acts as having no password provided at all.
 	PassFunc cosign.PassFunc
 
 	// MaxRetries indicates the number of times to retry operations
@@ -74,7 +73,6 @@ func Default() *Options {
 	return &Options{
 		Logger:               logrus.StandardLogger(),
 		Timeout:              3 * time.Minute,
-		PassFunc:             generate.GetPass,
 		EnableTokenProviders: true,
 		AttachSignature:      true,
 		MaxRetries:           3,


### PR DESCRIPTION

#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
This resolves two outstanding TODO's, because we can now pass `nil` to
`cosign.GenerateKeyPair`. Beside that, we also use `nil` as default
PassFunc, because this will be handled in the same way as providing no
password at all.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
cc @kubernetes-sigs/release-engineering 
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Changed default sign `Options.PassFunc` to be `nil`, which acts as having no password provided at all.
```
