### PR TITLE
Add support for GitHub actions e2e tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
-      interval: "daily"
+    interval: "daily"
   labels:
     - "area/dependency"
     - "release-note-none"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,48 @@
+---
+name: e2e
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+env:
+  GO_VERSION: '1.18'
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - name: Setup golang
+        uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Restore cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-${{ hashFiles('**/go.sum') }}
+          restore-keys: go-
+      - name: Run local registry
+        run: podman run -d -p 5000:5000 registry:2
+      - name: Build test image
+        uses: redhat-actions/buildah-build@d097e2e3d2a45b68a7c09040e3de33427bab66af
+        id: test-image
+        with:
+          base-image: scratch
+          image: test
+          oci: true
+      - name: Push test image to local registry
+        uses: redhat-actions/push-to-registry@df878026e36864aa6bf9a5b7afe63637cb88ef8c
+        with:
+          image: ${{ steps.test-image.outputs.image }}
+          registry: localhost:5000
+          tls-verify: false
+      - name: Run e2e tests
+        run: go run mage.go E2ETest

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,1 +1,7 @@
+---
 dependencies:
+  - name: go
+    version: 1.18
+    refPaths:
+      - path: .github/workflows/e2e.yml
+        match: GO_VERSION

--- a/magefile.go
+++ b/magefile.go
@@ -75,6 +75,19 @@ func IntegrationTest() error {
 	return nil
 }
 
+// E2ETest runs the end-to-end test functions.
+func E2ETest() error {
+	if err := mage.EnsureGitConfig(); err != nil {
+		return err
+	}
+
+	if err := mage.TestGoWithTags(true, "e2e", "test/e2e"); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // Verify runs repository verification scripts
 func Verify() error {
 	fmt.Println("Ensuring mage is available...")

--- a/sign/object.go
+++ b/sign/object.go
@@ -19,8 +19,18 @@ package sign
 // SignedObject contains additional metadata from the signing and verification
 // process.
 type SignedObject struct {
-	Image *SignedImage
-	File  *SignedFile
+	image *SignedImage
+	file  *SignedFile
+}
+
+// Image returns the image of the signed object and nil if it's a file.
+func (s *SignedObject) Image() *SignedImage {
+	return s.image
+}
+
+// File returns the file of the signed object and nil if it's an image.
+func (s *SignedObject) File() *SignedFile {
+	return s.file
 }
 
 // SignedFile contains additional metadata from the signing and verification
@@ -32,24 +42,24 @@ type SignedFile struct {
 	certificatePath string
 }
 
-// Path return the path hash of the signed file.
-func (f *SignedFile) Path() string {
-	return f.path
+// Path returns the path hash of the signed file.
+func (s *SignedFile) Path() string {
+	return s.path
 }
 
-// SHA256 return the SHA256 hash of the signed file.
-func (f *SignedFile) SHA256() string {
-	return f.sha256
+// SHA256 returns the SHA256 hash of the signed file.
+func (s *SignedFile) SHA256() string {
+	return s.sha256
 }
 
-// SignaturePath return the path to the Signature output of the signed file.
-func (f *SignedFile) SignaturePath() string {
-	return f.signaturePath
+// SignaturePath returns the path to the Signature output of the signed file.
+func (s *SignedFile) SignaturePath() string {
+	return s.signaturePath
 }
 
-// CertificatePath return the path to the Certificate output of the signed file.
-func (f *SignedFile) CertificatePath() string {
-	return f.certificatePath
+// CertificatePath returns the path to the Certificate output of the signed file.
+func (s *SignedFile) CertificatePath() string {
+	return s.certificatePath
 }
 
 // SignedImage contains additional metadata from the signing and verification
@@ -61,16 +71,16 @@ type SignedImage struct {
 }
 
 // Reference returns the OCI registry reference of the object.
-func (m *SignedImage) Reference() string {
-	return m.reference
+func (s *SignedImage) Reference() string {
+	return s.reference
 }
 
 // Digest returns the digest of the signed object.
-func (m *SignedImage) Digest() string {
-	return m.digest
+func (s *SignedImage) Digest() string {
+	return s.digest
 }
 
 // Signature returns the signature of the signed object.
-func (m *SignedImage) Signature() string {
-	return m.signature
+func (s *SignedImage) Signature() string {
+	return s.signature
 }

--- a/sign/sign.go
+++ b/sign/sign.go
@@ -39,6 +39,10 @@ type Signer struct {
 
 // New returns a new Signer instance.
 func New(options *Options) *Signer {
+	if options == nil {
+		options = Default()
+	}
+
 	if options.Logger == nil {
 		options.Logger = logrus.New()
 	}
@@ -231,7 +235,7 @@ func (s *Signer) SignFile(path string) (*SignedObject, error) {
 	}
 
 	return &SignedObject{
-		File: &SignedFile{
+		file: &SignedFile{
 			path:            path,
 			sha256:          fileSHA,
 			signaturePath:   s.options.OutputSignaturePath,
@@ -285,7 +289,7 @@ func (s *Signer) VerifyImage(reference string) (*SignedObject, error) {
 
 	sigParsed := strings.ReplaceAll(dig, "sha256:", "sha256-")
 	obj := &SignedObject{
-		Image: &SignedImage{
+		image: &SignedImage{
 			digest:    dig,
 			reference: ref.String(),
 			signature: fmt.Sprintf("%s:%s.sig", ref.Context().Name(), sigParsed),
@@ -342,7 +346,7 @@ func (s *Signer) VerifyFile(path string) (*SignedObject, error) {
 	}
 
 	return &SignedObject{
-		File: &SignedFile{
+		file: &SignedFile{
 			path:            path,
 			sha256:          fileSHA,
 			signaturePath:   s.options.OutputSignaturePath,

--- a/sign/sign_test.go
+++ b/sign/sign_test.go
@@ -88,12 +88,12 @@ func TestSignImage(t *testing.T) {
 			assert: func(obj *sign.SignedObject, err error) {
 				require.NoError(t, err)
 				require.NotNil(t, obj)
-				require.NotEmpty(t, obj.Image.Reference())
-				require.NotEmpty(t, obj.Image.Digest())
-				require.NotEmpty(t, obj.Image.Signature())
-				require.Equal(t, obj.Image.Reference(), "gcr.io/fake/honk:99.99.99")
-				require.Equal(t, obj.Image.Digest(), "sha256:honk69059c8e84bed02f4c4385d432808e2c8055eb5087f7fea74e286b736a")
-				require.Equal(t, obj.Image.Signature(), "gcr.io/fake/honk:sha256-honk69059c8e84bed02f4c4385d432808e2c8055eb5087f7fea74e286b736a.sig")
+				require.NotEmpty(t, obj.Image().Reference())
+				require.NotEmpty(t, obj.Image().Digest())
+				require.NotEmpty(t, obj.Image().Signature())
+				require.Equal(t, obj.Image().Reference(), "gcr.io/fake/honk:99.99.99")
+				require.Equal(t, obj.Image().Digest(), "sha256:honk69059c8e84bed02f4c4385d432808e2c8055eb5087f7fea74e286b736a")
+				require.Equal(t, obj.Image().Signature(), "gcr.io/fake/honk:sha256-honk69059c8e84bed02f4c4385d432808e2c8055eb5087f7fea74e286b736a.sig")
 			},
 		},
 		{ // Success with failed unset experimental
@@ -115,12 +115,12 @@ func TestSignImage(t *testing.T) {
 			assert: func(obj *sign.SignedObject, err error) {
 				require.NoError(t, err)
 				require.NotNil(t, obj)
-				require.NotEmpty(t, obj.Image.Reference())
-				require.NotEmpty(t, obj.Image.Digest())
-				require.NotEmpty(t, obj.Image.Signature())
-				require.Equal(t, obj.Image.Reference(), "gcr.io/fake/honk:99.99.99")
-				require.Equal(t, obj.Image.Digest(), "sha256:honk69059c8e84bed02f4c4385d432808e2c8055eb5087f7fea74e286b736a")
-				require.Equal(t, obj.Image.Signature(), "gcr.io/fake/honk:sha256-honk69059c8e84bed02f4c4385d432808e2c8055eb5087f7fea74e286b736a.sig")
+				require.NotEmpty(t, obj.Image().Reference())
+				require.NotEmpty(t, obj.Image().Digest())
+				require.NotEmpty(t, obj.Image().Signature())
+				require.Equal(t, obj.Image().Reference(), "gcr.io/fake/honk:99.99.99")
+				require.Equal(t, obj.Image().Digest(), "sha256:honk69059c8e84bed02f4c4385d432808e2c8055eb5087f7fea74e286b736a")
+				require.Equal(t, obj.Image().Signature(), "gcr.io/fake/honk:sha256-honk69059c8e84bed02f4c4385d432808e2c8055eb5087f7fea74e286b736a.sig")
 			},
 		},
 		{ // Failure on Verify
@@ -238,9 +238,9 @@ func TestSignFile(t *testing.T) {
 			assert: func(obj *sign.SignedObject, err error) {
 				require.Nil(t, err)
 				require.NotNil(t, obj)
-				require.NotEmpty(t, obj.File.Path())
-				require.NotEmpty(t, obj.File.CertificatePath())
-				require.NotEmpty(t, obj.File.SignaturePath())
+				require.NotEmpty(t, obj.File().Path())
+				require.NotEmpty(t, obj.File().CertificatePath())
+				require.NotEmpty(t, obj.File().SignaturePath())
 			},
 		},
 		{ // Success custom sig and cert.
@@ -257,9 +257,9 @@ func TestSignFile(t *testing.T) {
 			assert: func(obj *sign.SignedObject, err error) {
 				require.Nil(t, err)
 				require.NotNil(t, obj)
-				require.NotEmpty(t, obj.File.Path())
-				require.NotEmpty(t, obj.File.CertificatePath())
-				require.NotEmpty(t, obj.File.SignaturePath())
+				require.NotEmpty(t, obj.File().Path())
+				require.NotEmpty(t, obj.File().CertificatePath())
+				require.NotEmpty(t, obj.File().SignaturePath())
 			},
 		},
 		{ // File does not exist.
@@ -295,12 +295,12 @@ func TestSignFile(t *testing.T) {
 				require.Nil(t, err)
 
 				require.NotNil(t, obj)
-				require.NotEmpty(t, obj.File.Path())
-				require.NotEmpty(t, obj.File.CertificatePath())
-				require.NotEmpty(t, obj.File.SignaturePath())
+				require.NotEmpty(t, obj.File().Path())
+				require.NotEmpty(t, obj.File().CertificatePath())
+				require.NotEmpty(t, obj.File().SignaturePath())
 
-				require.Equal(t, obj.File.Path()+".cert", obj.File.CertificatePath())
-				require.Equal(t, obj.File.Path()+".sig", obj.File.SignaturePath())
+				require.Equal(t, obj.File().Path()+".cert", obj.File().CertificatePath())
+				require.Equal(t, obj.File().Path()+".sig", obj.File().SignaturePath())
 			},
 		},
 		{ // Verify failed.
@@ -373,12 +373,12 @@ func TestVerifyImage(t *testing.T) {
 			},
 			assert: func(obj *sign.SignedObject, err error) {
 				require.NotNil(t, obj)
-				require.NotEmpty(t, obj.Image.Reference())
-				require.NotEmpty(t, obj.Image.Digest())
-				require.NotEmpty(t, obj.Image.Signature())
-				require.Equal(t, obj.Image.Reference(), "gcr.io/fake/honk:99.99.99")
-				require.Equal(t, obj.Image.Digest(), "sha256:honk69059c8e84bed02f4c4385d432808e2c8055eb5087f7fea74e286b736a")
-				require.Equal(t, obj.Image.Signature(), "gcr.io/fake/honk:sha256-honk69059c8e84bed02f4c4385d432808e2c8055eb5087f7fea74e286b736a.sig")
+				require.NotEmpty(t, obj.Image().Reference())
+				require.NotEmpty(t, obj.Image().Digest())
+				require.NotEmpty(t, obj.Image().Signature())
+				require.Equal(t, obj.Image().Reference(), "gcr.io/fake/honk:99.99.99")
+				require.Equal(t, obj.Image().Digest(), "sha256:honk69059c8e84bed02f4c4385d432808e2c8055eb5087f7fea74e286b736a")
+				require.Equal(t, obj.Image().Signature(), "gcr.io/fake/honk:sha256-honk69059c8e84bed02f4c4385d432808e2c8055eb5087f7fea74e286b736a.sig")
 				require.Nil(t, err)
 			},
 		},
@@ -475,8 +475,8 @@ func TestVerifyFile(t *testing.T) {
 			},
 			assert: func(obj *sign.SignedObject, err error) {
 				require.NotNil(t, obj.File)
-				require.Equal(t, obj.File.Path(), tempFile)
-				require.Equal(t, obj.File.SHA256(), payloadSha256)
+				require.Equal(t, obj.File().Path(), tempFile)
+				require.Equal(t, obj.File().SHA256(), payloadSha256)
 				require.Nil(t, err)
 			},
 		},

--- a/test/e2e/sign_test.go
+++ b/test/e2e/sign_test.go
@@ -1,0 +1,101 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/release-sdk/sign"
+)
+
+const (
+	ociManifestType   = "application/vnd.oci.image.manifest.v1+json"
+	registry          = "localhost:5000"
+	imageName         = "test"
+	registryWithImage = registry + "/" + imageName
+	imageRef          = registryWithImage + ":latest"
+)
+
+func TestSignImageSuccess(t *testing.T) {
+	// Test the prerequisites
+	signer := sign.New(nil)
+	signed, err := signer.IsImageSigned(imageRef)
+	require.Nil(t, err)
+	require.False(t, signed)
+
+	// Sign the image
+	res, err := signer.SignImage(imageRef)
+
+	// Verify the results
+	assert.Nil(t, err)
+	assert.Nil(t, res.File())
+	image := res.Image()
+	assert.NotNil(t, image)
+	assert.Equal(t, imageRef, image.Reference())
+	assert.Regexp(t, `sha256:[[:xdigit:]]{64}`, image.Digest())
+	assert.Regexp(t, registryWithImage+`:sha256-[[:xdigit:]]{64}\.sig`, image.Signature())
+
+	url := fmt.Sprintf(
+		"http://%s/v2/%s/manifests/%s",
+		registry,
+		imageName,
+		strings.Replace(image.Signature(), registryWithImage+":", "", 1),
+	)
+	fmt.Printf(": %s\n", url)
+
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", url, nil)
+	require.Nil(t, err)
+	req.Header.Set("Accept", ociManifestType)
+
+	resp, err := client.Do(req)
+	require.Nil(t, err)
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	require.Nil(t, err)
+
+	response := string(body)
+	assert.Contains(t, response, "-----BEGIN CERTIFICATE-----")
+	assert.Contains(t, response, "-----END CERTIFICATE-----")
+	assert.Contains(t, response, fmt.Sprintf(`"mediaType":"%s"`, ociManifestType))
+
+	signed, err = signer.IsImageSigned(imageRef)
+	require.Nil(t, err)
+	assert.True(t, signed)
+
+	obj, err := signer.VerifyImage(imageRef)
+	require.Nil(t, err)
+	assert.Equal(t, res, obj)
+}
+
+func TestSignImageFailureWrongImageRef(t *testing.T) {
+	// Test the prerequisites
+	signer := sign.New(nil)
+	_, err := signer.SignImage(registry + "/not-existing:latest")
+	assert.ErrorContains(t, err, "entity not found in registry")
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind api-change

#### What this PR does / why we need it:

We now add support for running e2e tests via GitHub actions.

Beside that, we also add accessor methods for `Image()` and `File()` of `SignedObject` to keep the API separated.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
Last CI run in my fork: https://github.com/saschagrunert/release-sdk/runs/7407613686
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added accessor methods for `Image()` and `File()` of `SignedObject`.
```

cc @kubernetes-sigs/release-engineering 