### PR TITLE
remove pull_request target that does not work with fork prs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
 
 env:
   GO_VERSION: '1.18'
@@ -21,6 +20,7 @@ jobs:
         uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a
         with:
           go-version: ${{ env.GO_VERSION }}
+          check-latest: true
       - name: Restore cache
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

follow up of https://github.com/kubernetes-sigs/release-sdk/pull/91 

the Identity token is not inject when the PR come from a fork. to we inject that we need to use the `pull_request_target` but that might generate possible security issues.
However this repository does not have any secrets or sensitive data, but the attacker can use the token for other things.
So removing the `pull_request` target for now.

/assign @ameukam @saschagrunert @puerco @jeremyrickard @palnabarun  
cc @kubernetes-sigs/release-engineering 


#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
