### PR TITLE
Add `ImagesSigned` API

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -118,6 +118,8 @@ linters-settings:
   errcheck:
     check-type-assertions: true
     check-blank: true
+  gocognit:
+    min-complexity: 40
   gocritic:
     enabled-checks:
       # Diagnostic

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/google/go-github/v47 v47.1.0
 	github.com/magefile/mage v1.14.0
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.5.0
+	github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481
 	github.com/sigstore/cosign v1.13.1
 	github.com/sigstore/rekor v1.0.0
 	github.com/sirupsen/logrus v1.9.0
@@ -213,6 +214,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.13.0 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.1.1 // indirect
+	github.com/stretchr/objx v0.4.0 // indirect
 	github.com/subosito/gotenv v1.4.1 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d // indirect
 	github.com/tchap/go-patricia/v2 v2.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1078,6 +1078,8 @@ github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OS
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nightlyone/lockfile v1.0.0/go.mod h1:rywoIealpdNse2r832aiD9jRk8ErCatROs6LzC841CI=
 github.com/nishanths/predeclared v0.0.0-20200524104333-86fad755b4d3/go.mod h1:nt3d53pc1VYcphSCIaYAJtnPYnr3Zyn8fMq2wvPGPso=
+github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481 h1:Up6+btDp321ZG5/zdSLo48H9Iaq0UQGthrhWC6pCxzE=
+github.com/nozzle/throttler v0.0.0-20180817012639-2ea982251481/go.mod h1:yKZQO8QE2bHlgozqWDiRVqTFlLQSj30K/6SAK8EeYFw=
 github.com/nwaples/rardecode v1.1.0 h1:vSxaY8vQhOcVr4mm5e8XllHWTiM4JF507A0Katqw7MQ=
 github.com/nwaples/rardecode v1.1.0/go.mod h1:5DzqNKiOdpKKBH87u8VlvAnPZMXcGRhxWkRpHbbfGS0=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
@@ -1332,6 +1334,7 @@ github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5J
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
+github.com/stretchr/objx v0.4.0 h1:M2gUjqZET1qApGOWNSnZ49BAIMX4F/1plDv3+l31EJ4=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v0.0.0-20170130113145-4d4bfba8f1d1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/sign/impl.go
+++ b/sign/impl.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"sync"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/crane"
@@ -32,8 +33,6 @@ import (
 	"github.com/sigstore/cosign/cmd/cosign/cli/verify"
 	"github.com/sigstore/cosign/pkg/blob"
 	"github.com/sigstore/cosign/pkg/cosign"
-	"github.com/sigstore/cosign/pkg/oci"
-	"github.com/sigstore/cosign/pkg/oci/remote"
 	"github.com/sigstore/cosign/pkg/providers"
 	"github.com/sigstore/rekor/pkg/generated/client"
 	"github.com/sirupsen/logrus"
@@ -63,12 +62,10 @@ type impl interface {
 	ParseReference(string, ...name.Option) (name.Reference, error)
 	FindTLogEntriesByPayload(ctx context.Context, rClient *client.Rekor, blobBytes []byte) ([]string, error)
 	Digest(ref string, opt ...crane.Option) (string, error)
-	SignedEntity(name.Reference, ...remote.Option) (oci.SignedEntity, error)
-	Signatures(oci.SignedEntity) (oci.Signatures, error)
-	SignaturesList(oci.Signatures) ([]oci.Signature, error)
 	PayloadBytes(blobRef string) ([]byte, error)
 	NewRekorClient(string) (*client.Rekor, error)
 	NewWithContext(context.Context, name.Registry, authn.Authenticator, http.RoundTripper, []string) (http.RoundTripper, error)
+	ImagesSigned(context.Context, *Signer, string) (*sync.Map, error)
 }
 
 func (*defaultImpl) VerifyFileInternal(ctx context.Context, ko options.KeyOpts, outputSignature, //nolint: gocritic
@@ -155,24 +152,6 @@ func (*defaultImpl) Digest(
 	return crane.Digest(ref, opts...)
 }
 
-func (*defaultImpl) SignedEntity(
-	ref name.Reference, opts ...remote.Option,
-) (oci.SignedEntity, error) {
-	return remote.SignedEntity(ref, opts...)
-}
-
-func (*defaultImpl) Signatures(
-	entity oci.SignedEntity,
-) (oci.Signatures, error) {
-	return entity.Signatures()
-}
-
-func (*defaultImpl) SignaturesList(
-	signatures oci.Signatures,
-) ([]oci.Signature, error) {
-	return signatures.Get()
-}
-
 func (*defaultImpl) PayloadBytes(blobRef string) (blobBytes []byte, err error) {
 	blobBytes, err = blob.LoadFileOrURL(blobRef)
 	if err != nil {
@@ -193,4 +172,8 @@ func (*defaultImpl) NewWithContext(
 	scopes []string,
 ) (http.RoundTripper, error) {
 	return transport.NewWithContext(ctx, reg, auth, t, scopes)
+}
+
+func (d *defaultImpl) ImagesSigned(ctx context.Context, s *Signer, ref string) (*sync.Map, error) {
+	return s.ImagesSigned(ctx, ref)
 }

--- a/sign/options.go
+++ b/sign/options.go
@@ -66,6 +66,10 @@ type Options struct {
 	// MaxRetries indicates the number of times to retry operations
 	// when transient failures occur
 	MaxRetries uint
+
+	// The amount of maximum workers for parallel executions.
+	// Defaults to 100.
+	MaxWorkers uint
 }
 
 // Default returns a default Options instance.
@@ -76,6 +80,7 @@ func Default() *Options {
 		EnableTokenProviders: true,
 		AttachSignature:      true,
 		MaxRetries:           3,
+		MaxWorkers:           100,
 	}
 }
 

--- a/sign/signfakes/fake_impl.go
+++ b/sign/signfakes/fake_impl.go
@@ -26,8 +26,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/sigstore/cosign/cmd/cosign/cli/options"
-	"github.com/sigstore/cosign/pkg/oci"
-	"github.com/sigstore/cosign/pkg/oci/remote"
 	"github.com/sigstore/rekor/pkg/generated/client"
 	"github.com/sirupsen/logrus"
 	"sigs.k8s.io/release-sdk/sign"
@@ -84,6 +82,21 @@ type FakeImpl struct {
 	}
 	findTLogEntriesByPayloadReturnsOnCall map[int]struct {
 		result1 []string
+		result2 error
+	}
+	ImagesSignedStub        func(context.Context, *sign.Signer, string) (*sync.Map, error)
+	imagesSignedMutex       sync.RWMutex
+	imagesSignedArgsForCall []struct {
+		arg1 context.Context
+		arg2 *sign.Signer
+		arg3 string
+	}
+	imagesSignedReturns struct {
+		result1 *sync.Map
+		result2 error
+	}
+	imagesSignedReturnsOnCall map[int]struct {
+		result1 *sync.Map
 		result2 error
 	}
 	NewRekorClientStub        func(string) (*client.Rekor, error)
@@ -195,46 +208,6 @@ type FakeImpl struct {
 	}
 	signImageInternalReturnsOnCall map[int]struct {
 		result1 error
-	}
-	SignaturesStub        func(oci.SignedEntity) (oci.Signatures, error)
-	signaturesMutex       sync.RWMutex
-	signaturesArgsForCall []struct {
-		arg1 oci.SignedEntity
-	}
-	signaturesReturns struct {
-		result1 oci.Signatures
-		result2 error
-	}
-	signaturesReturnsOnCall map[int]struct {
-		result1 oci.Signatures
-		result2 error
-	}
-	SignaturesListStub        func(oci.Signatures) ([]oci.Signature, error)
-	signaturesListMutex       sync.RWMutex
-	signaturesListArgsForCall []struct {
-		arg1 oci.Signatures
-	}
-	signaturesListReturns struct {
-		result1 []oci.Signature
-		result2 error
-	}
-	signaturesListReturnsOnCall map[int]struct {
-		result1 []oci.Signature
-		result2 error
-	}
-	SignedEntityStub        func(name.Reference, ...remote.Option) (oci.SignedEntity, error)
-	signedEntityMutex       sync.RWMutex
-	signedEntityArgsForCall []struct {
-		arg1 name.Reference
-		arg2 []remote.Option
-	}
-	signedEntityReturns struct {
-		result1 oci.SignedEntity
-		result2 error
-	}
-	signedEntityReturnsOnCall map[int]struct {
-		result1 oci.SignedEntity
-		result2 error
 	}
 	TokenFromProvidersStub        func(context.Context, *logrus.Logger) (string, error)
 	tokenFromProvidersMutex       sync.RWMutex
@@ -539,6 +512,72 @@ func (fake *FakeImpl) FindTLogEntriesByPayloadReturnsOnCall(i int, result1 []str
 	}
 	fake.findTLogEntriesByPayloadReturnsOnCall[i] = struct {
 		result1 []string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeImpl) ImagesSigned(arg1 context.Context, arg2 *sign.Signer, arg3 string) (*sync.Map, error) {
+	fake.imagesSignedMutex.Lock()
+	ret, specificReturn := fake.imagesSignedReturnsOnCall[len(fake.imagesSignedArgsForCall)]
+	fake.imagesSignedArgsForCall = append(fake.imagesSignedArgsForCall, struct {
+		arg1 context.Context
+		arg2 *sign.Signer
+		arg3 string
+	}{arg1, arg2, arg3})
+	stub := fake.ImagesSignedStub
+	fakeReturns := fake.imagesSignedReturns
+	fake.recordInvocation("ImagesSigned", []interface{}{arg1, arg2, arg3})
+	fake.imagesSignedMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeImpl) ImagesSignedCallCount() int {
+	fake.imagesSignedMutex.RLock()
+	defer fake.imagesSignedMutex.RUnlock()
+	return len(fake.imagesSignedArgsForCall)
+}
+
+func (fake *FakeImpl) ImagesSignedCalls(stub func(context.Context, *sign.Signer, string) (*sync.Map, error)) {
+	fake.imagesSignedMutex.Lock()
+	defer fake.imagesSignedMutex.Unlock()
+	fake.ImagesSignedStub = stub
+}
+
+func (fake *FakeImpl) ImagesSignedArgsForCall(i int) (context.Context, *sign.Signer, string) {
+	fake.imagesSignedMutex.RLock()
+	defer fake.imagesSignedMutex.RUnlock()
+	argsForCall := fake.imagesSignedArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeImpl) ImagesSignedReturns(result1 *sync.Map, result2 error) {
+	fake.imagesSignedMutex.Lock()
+	defer fake.imagesSignedMutex.Unlock()
+	fake.ImagesSignedStub = nil
+	fake.imagesSignedReturns = struct {
+		result1 *sync.Map
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeImpl) ImagesSignedReturnsOnCall(i int, result1 *sync.Map, result2 error) {
+	fake.imagesSignedMutex.Lock()
+	defer fake.imagesSignedMutex.Unlock()
+	fake.ImagesSignedStub = nil
+	if fake.imagesSignedReturnsOnCall == nil {
+		fake.imagesSignedReturnsOnCall = make(map[int]struct {
+			result1 *sync.Map
+			result2 error
+		})
+	}
+	fake.imagesSignedReturnsOnCall[i] = struct {
+		result1 *sync.Map
 		result2 error
 	}{result1, result2}
 }
@@ -1017,199 +1056,6 @@ func (fake *FakeImpl) SignImageInternalReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeImpl) Signatures(arg1 oci.SignedEntity) (oci.Signatures, error) {
-	fake.signaturesMutex.Lock()
-	ret, specificReturn := fake.signaturesReturnsOnCall[len(fake.signaturesArgsForCall)]
-	fake.signaturesArgsForCall = append(fake.signaturesArgsForCall, struct {
-		arg1 oci.SignedEntity
-	}{arg1})
-	stub := fake.SignaturesStub
-	fakeReturns := fake.signaturesReturns
-	fake.recordInvocation("Signatures", []interface{}{arg1})
-	fake.signaturesMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *FakeImpl) SignaturesCallCount() int {
-	fake.signaturesMutex.RLock()
-	defer fake.signaturesMutex.RUnlock()
-	return len(fake.signaturesArgsForCall)
-}
-
-func (fake *FakeImpl) SignaturesCalls(stub func(oci.SignedEntity) (oci.Signatures, error)) {
-	fake.signaturesMutex.Lock()
-	defer fake.signaturesMutex.Unlock()
-	fake.SignaturesStub = stub
-}
-
-func (fake *FakeImpl) SignaturesArgsForCall(i int) oci.SignedEntity {
-	fake.signaturesMutex.RLock()
-	defer fake.signaturesMutex.RUnlock()
-	argsForCall := fake.signaturesArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakeImpl) SignaturesReturns(result1 oci.Signatures, result2 error) {
-	fake.signaturesMutex.Lock()
-	defer fake.signaturesMutex.Unlock()
-	fake.SignaturesStub = nil
-	fake.signaturesReturns = struct {
-		result1 oci.Signatures
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeImpl) SignaturesReturnsOnCall(i int, result1 oci.Signatures, result2 error) {
-	fake.signaturesMutex.Lock()
-	defer fake.signaturesMutex.Unlock()
-	fake.SignaturesStub = nil
-	if fake.signaturesReturnsOnCall == nil {
-		fake.signaturesReturnsOnCall = make(map[int]struct {
-			result1 oci.Signatures
-			result2 error
-		})
-	}
-	fake.signaturesReturnsOnCall[i] = struct {
-		result1 oci.Signatures
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeImpl) SignaturesList(arg1 oci.Signatures) ([]oci.Signature, error) {
-	fake.signaturesListMutex.Lock()
-	ret, specificReturn := fake.signaturesListReturnsOnCall[len(fake.signaturesListArgsForCall)]
-	fake.signaturesListArgsForCall = append(fake.signaturesListArgsForCall, struct {
-		arg1 oci.Signatures
-	}{arg1})
-	stub := fake.SignaturesListStub
-	fakeReturns := fake.signaturesListReturns
-	fake.recordInvocation("SignaturesList", []interface{}{arg1})
-	fake.signaturesListMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *FakeImpl) SignaturesListCallCount() int {
-	fake.signaturesListMutex.RLock()
-	defer fake.signaturesListMutex.RUnlock()
-	return len(fake.signaturesListArgsForCall)
-}
-
-func (fake *FakeImpl) SignaturesListCalls(stub func(oci.Signatures) ([]oci.Signature, error)) {
-	fake.signaturesListMutex.Lock()
-	defer fake.signaturesListMutex.Unlock()
-	fake.SignaturesListStub = stub
-}
-
-func (fake *FakeImpl) SignaturesListArgsForCall(i int) oci.Signatures {
-	fake.signaturesListMutex.RLock()
-	defer fake.signaturesListMutex.RUnlock()
-	argsForCall := fake.signaturesListArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakeImpl) SignaturesListReturns(result1 []oci.Signature, result2 error) {
-	fake.signaturesListMutex.Lock()
-	defer fake.signaturesListMutex.Unlock()
-	fake.SignaturesListStub = nil
-	fake.signaturesListReturns = struct {
-		result1 []oci.Signature
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeImpl) SignaturesListReturnsOnCall(i int, result1 []oci.Signature, result2 error) {
-	fake.signaturesListMutex.Lock()
-	defer fake.signaturesListMutex.Unlock()
-	fake.SignaturesListStub = nil
-	if fake.signaturesListReturnsOnCall == nil {
-		fake.signaturesListReturnsOnCall = make(map[int]struct {
-			result1 []oci.Signature
-			result2 error
-		})
-	}
-	fake.signaturesListReturnsOnCall[i] = struct {
-		result1 []oci.Signature
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeImpl) SignedEntity(arg1 name.Reference, arg2 ...remote.Option) (oci.SignedEntity, error) {
-	fake.signedEntityMutex.Lock()
-	ret, specificReturn := fake.signedEntityReturnsOnCall[len(fake.signedEntityArgsForCall)]
-	fake.signedEntityArgsForCall = append(fake.signedEntityArgsForCall, struct {
-		arg1 name.Reference
-		arg2 []remote.Option
-	}{arg1, arg2})
-	stub := fake.SignedEntityStub
-	fakeReturns := fake.signedEntityReturns
-	fake.recordInvocation("SignedEntity", []interface{}{arg1, arg2})
-	fake.signedEntityMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2...)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *FakeImpl) SignedEntityCallCount() int {
-	fake.signedEntityMutex.RLock()
-	defer fake.signedEntityMutex.RUnlock()
-	return len(fake.signedEntityArgsForCall)
-}
-
-func (fake *FakeImpl) SignedEntityCalls(stub func(name.Reference, ...remote.Option) (oci.SignedEntity, error)) {
-	fake.signedEntityMutex.Lock()
-	defer fake.signedEntityMutex.Unlock()
-	fake.SignedEntityStub = stub
-}
-
-func (fake *FakeImpl) SignedEntityArgsForCall(i int) (name.Reference, []remote.Option) {
-	fake.signedEntityMutex.RLock()
-	defer fake.signedEntityMutex.RUnlock()
-	argsForCall := fake.signedEntityArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
-}
-
-func (fake *FakeImpl) SignedEntityReturns(result1 oci.SignedEntity, result2 error) {
-	fake.signedEntityMutex.Lock()
-	defer fake.signedEntityMutex.Unlock()
-	fake.SignedEntityStub = nil
-	fake.signedEntityReturns = struct {
-		result1 oci.SignedEntity
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeImpl) SignedEntityReturnsOnCall(i int, result1 oci.SignedEntity, result2 error) {
-	fake.signedEntityMutex.Lock()
-	defer fake.signedEntityMutex.Unlock()
-	fake.SignedEntityStub = nil
-	if fake.signedEntityReturnsOnCall == nil {
-		fake.signedEntityReturnsOnCall = make(map[int]struct {
-			result1 oci.SignedEntity
-			result2 error
-		})
-	}
-	fake.signedEntityReturnsOnCall[i] = struct {
-		result1 oci.SignedEntity
-		result2 error
-	}{result1, result2}
-}
-
 func (fake *FakeImpl) TokenFromProviders(arg1 context.Context, arg2 *logrus.Logger) (string, error) {
 	fake.tokenFromProvidersMutex.Lock()
 	ret, specificReturn := fake.tokenFromProvidersReturnsOnCall[len(fake.tokenFromProvidersArgsForCall)]
@@ -1422,6 +1268,8 @@ func (fake *FakeImpl) Invocations() map[string][][]interface{} {
 	defer fake.fileExistsMutex.RUnlock()
 	fake.findTLogEntriesByPayloadMutex.RLock()
 	defer fake.findTLogEntriesByPayloadMutex.RUnlock()
+	fake.imagesSignedMutex.RLock()
+	defer fake.imagesSignedMutex.RUnlock()
 	fake.newRekorClientMutex.RLock()
 	defer fake.newRekorClientMutex.RUnlock()
 	fake.newWithContextMutex.RLock()
@@ -1436,12 +1284,6 @@ func (fake *FakeImpl) Invocations() map[string][][]interface{} {
 	defer fake.signFileInternalMutex.RUnlock()
 	fake.signImageInternalMutex.RLock()
 	defer fake.signImageInternalMutex.RUnlock()
-	fake.signaturesMutex.RLock()
-	defer fake.signaturesMutex.RUnlock()
-	fake.signaturesListMutex.RLock()
-	defer fake.signaturesListMutex.RUnlock()
-	fake.signedEntityMutex.RLock()
-	defer fake.signedEntityMutex.RUnlock()
 	fake.tokenFromProvidersMutex.RLock()
 	defer fake.tokenFromProvidersMutex.RUnlock()
 	fake.verifyFileInternalMutex.RLock()

--- a/sign/signfakes/fake_impl.go
+++ b/sign/signfakes/fake_impl.go
@@ -19,8 +19,10 @@ package signfakes
 
 import (
 	"context"
+	"net/http"
 	"sync"
 
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/sigstore/cosign/cmd/cosign/cli/options"
@@ -95,6 +97,23 @@ type FakeImpl struct {
 	}
 	newRekorClientReturnsOnCall map[int]struct {
 		result1 *client.Rekor
+		result2 error
+	}
+	NewWithContextStub        func(context.Context, name.Registry, authn.Authenticator, http.RoundTripper, []string) (http.RoundTripper, error)
+	newWithContextMutex       sync.RWMutex
+	newWithContextArgsForCall []struct {
+		arg1 context.Context
+		arg2 name.Registry
+		arg3 authn.Authenticator
+		arg4 http.RoundTripper
+		arg5 []string
+	}
+	newWithContextReturns struct {
+		result1 http.RoundTripper
+		result2 error
+	}
+	newWithContextReturnsOnCall map[int]struct {
+		result1 http.RoundTripper
 		result2 error
 	}
 	ParseReferenceStub        func(string, ...name.Option) (name.Reference, error)
@@ -584,6 +603,79 @@ func (fake *FakeImpl) NewRekorClientReturnsOnCall(i int, result1 *client.Rekor, 
 	}
 	fake.newRekorClientReturnsOnCall[i] = struct {
 		result1 *client.Rekor
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeImpl) NewWithContext(arg1 context.Context, arg2 name.Registry, arg3 authn.Authenticator, arg4 http.RoundTripper, arg5 []string) (http.RoundTripper, error) {
+	var arg5Copy []string
+	if arg5 != nil {
+		arg5Copy = make([]string, len(arg5))
+		copy(arg5Copy, arg5)
+	}
+	fake.newWithContextMutex.Lock()
+	ret, specificReturn := fake.newWithContextReturnsOnCall[len(fake.newWithContextArgsForCall)]
+	fake.newWithContextArgsForCall = append(fake.newWithContextArgsForCall, struct {
+		arg1 context.Context
+		arg2 name.Registry
+		arg3 authn.Authenticator
+		arg4 http.RoundTripper
+		arg5 []string
+	}{arg1, arg2, arg3, arg4, arg5Copy})
+	stub := fake.NewWithContextStub
+	fakeReturns := fake.newWithContextReturns
+	fake.recordInvocation("NewWithContext", []interface{}{arg1, arg2, arg3, arg4, arg5Copy})
+	fake.newWithContextMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeImpl) NewWithContextCallCount() int {
+	fake.newWithContextMutex.RLock()
+	defer fake.newWithContextMutex.RUnlock()
+	return len(fake.newWithContextArgsForCall)
+}
+
+func (fake *FakeImpl) NewWithContextCalls(stub func(context.Context, name.Registry, authn.Authenticator, http.RoundTripper, []string) (http.RoundTripper, error)) {
+	fake.newWithContextMutex.Lock()
+	defer fake.newWithContextMutex.Unlock()
+	fake.NewWithContextStub = stub
+}
+
+func (fake *FakeImpl) NewWithContextArgsForCall(i int) (context.Context, name.Registry, authn.Authenticator, http.RoundTripper, []string) {
+	fake.newWithContextMutex.RLock()
+	defer fake.newWithContextMutex.RUnlock()
+	argsForCall := fake.newWithContextArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
+}
+
+func (fake *FakeImpl) NewWithContextReturns(result1 http.RoundTripper, result2 error) {
+	fake.newWithContextMutex.Lock()
+	defer fake.newWithContextMutex.Unlock()
+	fake.NewWithContextStub = nil
+	fake.newWithContextReturns = struct {
+		result1 http.RoundTripper
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeImpl) NewWithContextReturnsOnCall(i int, result1 http.RoundTripper, result2 error) {
+	fake.newWithContextMutex.Lock()
+	defer fake.newWithContextMutex.Unlock()
+	fake.NewWithContextStub = nil
+	if fake.newWithContextReturnsOnCall == nil {
+		fake.newWithContextReturnsOnCall = make(map[int]struct {
+			result1 http.RoundTripper
+			result2 error
+		})
+	}
+	fake.newWithContextReturnsOnCall[i] = struct {
+		result1 http.RoundTripper
 		result2 error
 	}{result1, result2}
 }
@@ -1332,6 +1424,8 @@ func (fake *FakeImpl) Invocations() map[string][][]interface{} {
 	defer fake.findTLogEntriesByPayloadMutex.RUnlock()
 	fake.newRekorClientMutex.RLock()
 	defer fake.newRekorClientMutex.RUnlock()
+	fake.newWithContextMutex.RLock()
+	defer fake.newWithContextMutex.RUnlock()
 	fake.parseReferenceMutex.RLock()
 	defer fake.parseReferenceMutex.RUnlock()
 	fake.payloadBytesMutex.RLock()

--- a/test/integration/sign_test.go
+++ b/test/integration/sign_test.go
@@ -20,6 +20,7 @@ limitations under the License.
 package integration
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -145,6 +146,62 @@ func TestIsImageSigned(t *testing.T) {
 			require.Error(t, err)
 		} else {
 			require.NoError(t, err)
+		}
+	}
+}
+
+func TestImagesSigned(t *testing.T) {
+	signer := sign.New(sign.Default())
+	const repo = "k8s.gcr.io/security-profiles-operator/security-profiles-operator"
+	for _, tc := range []struct {
+		refs      map[string]bool
+		shouldErr bool
+	}{
+		{ // signed single image
+			map[string]bool{"ghcr.io/sigstore/cosign/cosign:f436d7637caaa9073522ae65a8416e38cd69c4f2": true},
+			false,
+		},
+		{ // nonexistent
+			map[string]bool{"kornotios/supermegafakeimage": false},
+			true,
+		},
+		{ // one valid and one nonexistent
+			map[string]bool{
+				"ghcr.io/sigstore/cosign/cosign:f436d7637caaa9073522ae65a8416e38cd69c4f2": true,
+				"kornotios/supermegafakeimage":                                            false,
+			},
+			true,
+		},
+		{ // list of valid images
+			map[string]bool{
+				repo + ":v0.2.0": false,
+				repo + ":v0.3.0": false,
+				repo + ":v0.4.0": false,
+				repo + ":v0.4.2": false,
+				repo + ":v0.4.3": true,
+				repo + ":v0.5.0": true,
+				repo + "@sha256:4e61cb64ab34d1b80ebdb900c636a2aff60d85c9a48b0f1d34202d9388856bd7": true,
+				repo + "@sha256:9da6d7f148b19154fd6df4cc052e6cd52787962369f34c7b0411f77b843f3d4c": true,
+			},
+			false,
+		},
+	} {
+		refs := []string{}
+		for ref := range tc.refs {
+			refs = append(refs, ref)
+		}
+
+		res, err := signer.ImagesSigned(context.Background(), refs...)
+		if tc.shouldErr {
+			require.Error(t, err)
+		} else {
+			require.NoError(t, err)
+
+			for ref, expected := range tc.refs {
+				signed, ok := res.Load(ref)
+				require.True(t, ok)
+				require.Equal(t, expected, signed)
+			}
 		}
 	}
 }


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
We now expose a new, highly parallel image signature verification API. This allows us to re-use built transports and efficiently looking up the signatures of the images.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to https://github.com/kubernetes-sigs/promo-tools/issues/637
#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `ImagesSigned` API
```
