### PR TITLE
block commands that can run malicious injection

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -334,7 +334,7 @@ func (r *Repo) SetMaxRetries(numRetries int) {
 }
 
 func LSRemoteExec(repoURL string, args ...string) (string, error) {
-	cmdArgs := append([]string{"ls-remote", repoURL}, args...)
+	cmdArgs := append([]string{"ls-remote", "--", repoURL}, args...)
 	cmdStatus, err := filterCommand("", cmdArgs...).
 		RunSilentSuccessOutput()
 	if err != nil {
@@ -1253,7 +1253,10 @@ func (r *Repo) PushToRemote(remote, remoteBranch string) error {
 // repository
 func (r *Repo) LsRemote(args ...string) (output string, err error) {
 	for i := r.maxRetries + 1; i > 0; i-- {
-		output, err = r.runGitCmd("ls-remote", args...)
+		params := []string{}
+		params = append(params, "--")
+		params = append(params, args...)
+		output, err = r.runGitCmd("ls-remote", params...)
 		if err == nil {
 			return output, nil
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

- block commands that can run malicious injection

/assign @saschagrunert @xmudrii @Verolop 
cc @kubernetes-sigs/release-engineering 


#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
