### PR TITLE
Make `git.DefaultGitUser` and `git.DefaultGitEmail` public

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -65,9 +65,13 @@ const (
 	// DefaultBranch is the default branch name
 	DefaultBranch = "master"
 
+	// DefaultGitUser is the default user name used for commits.
+	DefaultGitUser = "Kubernetes Release Robot"
+
+	// DefaultGitEmail is the default email used for commits.
+	DefaultGitEmail = "k8s-release-robot@users.noreply.github.com"
+
 	defaultGithubAuthRoot = "git@github.com:"
-	defaultGitUser        = "Kubernetes Release Robot"
-	defaultGitEmail       = "k8s-release-robot@users.noreply.github.com"
 	gitExecutable         = "git"
 	releaseBranchPrefix   = "release-"
 )
@@ -192,13 +196,13 @@ func GetRepoURL(org, repo string, useSSH bool) (repoURL string) {
 // user and email.
 func ConfigureGlobalDefaultUserAndEmail() error {
 	if err := filterCommand(
-		"", "config", "--global", "user.name", defaultGitUser,
+		"", "config", "--global", "user.name", DefaultGitUser,
 	).RunSuccess(); err != nil {
 		return fmt.Errorf("configure user name: %w", err)
 	}
 
 	if err := filterCommand(
-		"", "config", "--global", "user.email", defaultGitEmail,
+		"", "config", "--global", "user.email", DefaultGitEmail,
 	).RunSuccess(); err != nil {
 		return fmt.Errorf("configure user email: %w", err)
 	}
@@ -1098,8 +1102,8 @@ func (r *Repo) Commit(msg string) error {
 		msg,
 		&git.CommitOptions{
 			Author: &object.Signature{
-				Name:  defaultGitUser,
-				Email: defaultGitEmail,
+				Name:  DefaultGitUser,
+				Email: DefaultGitEmail,
 				When:  time.Now(),
 			},
 		},
@@ -1134,8 +1138,8 @@ func (r *Repo) Tag(name, message string) error {
 		head.Hash(),
 		&git.CreateTagOptions{
 			Tagger: &object.Signature{
-				Name:  defaultGitUser,
-				Email: defaultGitEmail,
+				Name:  DefaultGitUser,
+				Email: DefaultGitEmail,
 				When:  time.Now(),
 			},
 			Message: message,


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
I need both variables in k/release for some additional checks if a commit is from the bot a human.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to https://github.com/kubernetes/release/issues/2807
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Updated `git.DefaultGitUser` and `git.DefaultGitEmail` to be public constants.
```
