### PR TITLE
Add `ListIssues` GitHub API

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -143,6 +143,9 @@ type Client interface {
 	CreateComment(
 		context.Context, string, string, int, string,
 	) (*github.IssueComment, *github.Response, error)
+	ListIssues(
+		context.Context, string, string, *github.IssueListByRepoOptions,
+	) ([]*github.Issue, *github.Response, error)
 }
 
 // NewIssueOptions is a struct of optional fields for new issues
@@ -339,7 +342,7 @@ func (g *githubClient) ListBranches(
 ) ([]*github.Branch, *github.Response, error) {
 	branches, response, err := g.Repositories.ListBranches(ctx, owner, repo, opt)
 	if err != nil {
-		return nil, nil, fmt.Errorf("fetching brnaches from repo: %w", err)
+		return nil, nil, fmt.Errorf("fetching branches from repo: %w", err)
 	}
 
 	return branches, response, nil
@@ -476,6 +479,17 @@ func (g *githubClient) CreateComment(
 			return issueComment, resp, err
 		}
 	}
+}
+
+func (g *githubClient) ListIssues(
+	ctx context.Context, owner, repo string, opts *github.IssueListByRepoOptions,
+) ([]*github.Issue, *github.Response, error) {
+	issues, response, err := g.Issues.ListByRepo(ctx, owner, repo, opts)
+	if err != nil {
+		return nil, nil, fmt.Errorf("fetching issues from repo: %w", err)
+	}
+
+	return issues, response, nil
 }
 
 // SetClient can be used to manually set the internal GitHub client
@@ -1046,4 +1060,42 @@ func (g *githubClient) AddLabels(
 			return appliedLabels, resp, err
 		}
 	}
+}
+
+// IssueState is the enum for all available issue states.
+type IssueState string
+
+const (
+	// IssueStateAll can be used to list all issues.
+	IssueStateAll IssueState = "all"
+
+	// IssueStateOpen can be used to list only open issues.
+	IssueStateOpen IssueState = "open"
+
+	// IssueStateClosed can be used to list only closed issues.
+	IssueStateClosed IssueState = "closed"
+)
+
+// ListIssues gets the issues from a GitHub repository.
+// State filters issues based on their state. Possible values are: open,
+// closed, all. Default is "open".
+func (g *GitHub) ListIssues(owner, repo string, state IssueState) ([]*github.Issue, error) {
+	options := &github.IssueListByRepoOptions{
+		State:       string(state),
+		ListOptions: github.ListOptions{PerPage: g.Options().GetItemsPerPage()},
+	}
+	issues := []*github.Issue{}
+	for {
+		more, r, err := g.Client().ListIssues(context.Background(), owner, repo, options)
+		if err != nil {
+			return issues, fmt.Errorf("getting issues from client: %w", err)
+		}
+		issues = append(issues, more...)
+		if r.NextPage == 0 {
+			break
+		}
+		options.Page = r.NextPage
+	}
+
+	return issues, nil
 }

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -587,3 +587,30 @@ func TestAddLabels(t *testing.T) {
 		}
 	}
 }
+
+func TestListIssues(t *testing.T) {
+	// Given
+	sut, client := newSUT()
+
+	issue0 := "My title 1"
+	issue1 := "Create XYZ"
+	issue2 := "foo-bar"
+
+	issues := []*gogithub.Issue{
+		{Title: &issue0},
+		{Title: &issue1},
+		{Title: &issue2},
+	}
+
+	client.ListIssuesReturns(issues, &gogithub.Response{NextPage: 0}, nil)
+
+	// When
+	result, err := sut.ListIssues("kubernetes", "kubernotia", github.IssueStateOpen)
+
+	// Then
+	require.Nil(t, err)
+	require.Len(t, result, 3)
+	require.Equal(t, result[0].GetTitle(), issue0)
+	require.Equal(t, result[1].GetTitle(), issue1)
+	require.Equal(t, result[2].GetTitle(), issue2)
+}

--- a/github/githubfakes/fake_client.go
+++ b/github/githubfakes/fake_client.go
@@ -276,6 +276,24 @@ type FakeClient struct {
 		result2 *githuba.Response
 		result3 error
 	}
+	ListIssuesStub        func(context.Context, string, string, *githuba.IssueListByRepoOptions) ([]*githuba.Issue, *githuba.Response, error)
+	listIssuesMutex       sync.RWMutex
+	listIssuesArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 *githuba.IssueListByRepoOptions
+	}
+	listIssuesReturns struct {
+		result1 []*githuba.Issue
+		result2 *githuba.Response
+		result3 error
+	}
+	listIssuesReturnsOnCall map[int]struct {
+		result1 []*githuba.Issue
+		result2 *githuba.Response
+		result3 error
+	}
 	ListMilestonesStub        func(context.Context, string, string, *githuba.MilestoneListOptions) ([]*githuba.Milestone, *githuba.Response, error)
 	listMilestonesMutex       sync.RWMutex
 	listMilestonesArgsForCall []struct {
@@ -1401,6 +1419,76 @@ func (fake *FakeClient) ListCommitsReturnsOnCall(i int, result1 []*githuba.Repos
 	}{result1, result2, result3}
 }
 
+func (fake *FakeClient) ListIssues(arg1 context.Context, arg2 string, arg3 string, arg4 *githuba.IssueListByRepoOptions) ([]*githuba.Issue, *githuba.Response, error) {
+	fake.listIssuesMutex.Lock()
+	ret, specificReturn := fake.listIssuesReturnsOnCall[len(fake.listIssuesArgsForCall)]
+	fake.listIssuesArgsForCall = append(fake.listIssuesArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 *githuba.IssueListByRepoOptions
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.ListIssuesStub
+	fakeReturns := fake.listIssuesReturns
+	fake.recordInvocation("ListIssues", []interface{}{arg1, arg2, arg3, arg4})
+	fake.listIssuesMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeClient) ListIssuesCallCount() int {
+	fake.listIssuesMutex.RLock()
+	defer fake.listIssuesMutex.RUnlock()
+	return len(fake.listIssuesArgsForCall)
+}
+
+func (fake *FakeClient) ListIssuesCalls(stub func(context.Context, string, string, *githuba.IssueListByRepoOptions) ([]*githuba.Issue, *githuba.Response, error)) {
+	fake.listIssuesMutex.Lock()
+	defer fake.listIssuesMutex.Unlock()
+	fake.ListIssuesStub = stub
+}
+
+func (fake *FakeClient) ListIssuesArgsForCall(i int) (context.Context, string, string, *githuba.IssueListByRepoOptions) {
+	fake.listIssuesMutex.RLock()
+	defer fake.listIssuesMutex.RUnlock()
+	argsForCall := fake.listIssuesArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *FakeClient) ListIssuesReturns(result1 []*githuba.Issue, result2 *githuba.Response, result3 error) {
+	fake.listIssuesMutex.Lock()
+	defer fake.listIssuesMutex.Unlock()
+	fake.ListIssuesStub = nil
+	fake.listIssuesReturns = struct {
+		result1 []*githuba.Issue
+		result2 *githuba.Response
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeClient) ListIssuesReturnsOnCall(i int, result1 []*githuba.Issue, result2 *githuba.Response, result3 error) {
+	fake.listIssuesMutex.Lock()
+	defer fake.listIssuesMutex.Unlock()
+	fake.ListIssuesStub = nil
+	if fake.listIssuesReturnsOnCall == nil {
+		fake.listIssuesReturnsOnCall = make(map[int]struct {
+			result1 []*githuba.Issue
+			result2 *githuba.Response
+			result3 error
+		})
+	}
+	fake.listIssuesReturnsOnCall[i] = struct {
+		result1 []*githuba.Issue
+		result2 *githuba.Response
+		result3 error
+	}{result1, result2, result3}
+}
+
 func (fake *FakeClient) ListMilestones(arg1 context.Context, arg2 string, arg3 string, arg4 *githuba.MilestoneListOptions) ([]*githuba.Milestone, *githuba.Response, error) {
 	fake.listMilestonesMutex.Lock()
 	ret, specificReturn := fake.listMilestonesReturnsOnCall[len(fake.listMilestonesArgsForCall)]
@@ -1989,6 +2077,8 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.listBranchesMutex.RUnlock()
 	fake.listCommitsMutex.RLock()
 	defer fake.listCommitsMutex.RUnlock()
+	fake.listIssuesMutex.RLock()
+	defer fake.listIssuesMutex.RUnlock()
 	fake.listMilestonesMutex.RLock()
 	defer fake.listMilestonesMutex.RUnlock()
 	fake.listPullRequestsWithCommitMutex.RLock()

--- a/github/record.go
+++ b/github/record.go
@@ -49,6 +49,7 @@ const (
 	gitHubAPIListReleaseAssets          gitHubAPI = "ListReleaseAssets"
 	gitHubAPICreateComment              gitHubAPI = "CreateComment"
 	gitHubAPIListMilestones             gitHubAPI = "ListMilestones"
+	gitHubAPIListIssues                 gitHubAPI = "ListIssues"
 )
 
 type apiRecord struct {
@@ -309,6 +310,19 @@ func (c *githubNotesRecordClient) CreateComment(ctx context.Context, owner, repo
 		return nil, nil, err
 	}
 	return issueComment, resp, nil
+}
+
+func (c *githubNotesRecordClient) ListIssues(
+	ctx context.Context, owner, repo string, opts *github.IssueListByRepoOptions,
+) ([]*github.Issue, *github.Response, error) {
+	issues, resp, err := c.client.ListIssues(ctx, owner, repo, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := c.recordAPICall(gitHubAPIListIssues, issues, resp); err != nil {
+		return nil, nil, err
+	}
+	return issues, resp, nil
 }
 
 // recordAPICall records a single GitHub API call into a JSON file by ensuring

--- a/github/replay.go
+++ b/github/replay.go
@@ -321,3 +321,18 @@ func (c *githubNotesReplayClient) CreateComment(ctx context.Context, owner, repo
 	}
 	return result, record.response(), nil
 }
+
+func (c *githubNotesReplayClient) ListIssues(
+	ctx context.Context, owner, repo string, opts *github.IssueListByRepoOptions,
+) ([]*github.Issue, *github.Response, error) {
+	data, err := c.readRecordedData(gitHubAPIListIssues)
+	if err != nil {
+		return nil, nil, err
+	}
+	issues := make([]*github.Issue, 0)
+	record := apiRecord{Result: issues}
+	if err := json.Unmarshal(data, &record); err != nil {
+		return nil, nil, err
+	}
+	return issues, record.response(), nil
+}


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
We now have a way to list issues for GitHub repositories. 
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to https://github.com/kubernetes/release/issues/2807
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `github.ListIssues` API.
```
