### PR TITLE
Fix `RemoteTags()` method

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -1310,7 +1310,7 @@ func (r *Repo) IsDirty() (bool, error) {
 // RemoteTags return the tags that currently exist in the
 func (r *Repo) RemoteTags() (tags []string, err error) {
 	logrus.Debug("Listing remote tags with ls-remote")
-	output, err := r.LsRemote("--tags", DefaultRemote)
+	output, err := r.LsRemote(DefaultRemote)
 	if err != nil {
 		return tags, fmt.Errorf("while listing tags using ls-remote: %w", err)
 	}


### PR DESCRIPTION

#### What type of PR is this?


/kind bug
/kind regression

#### What this PR does / why we need it:
Fixing the broken method by removing the `--tags` arg.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
A regression from https://github.com/kubernetes-sigs/release-sdk/pull/136
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed `RemoteTags()` method
```
