### PR TITLE
go.mod: Update `github.com/google/go-github` to v48.2.0

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -26,7 +26,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/google/go-github/v47/github"
+	"github.com/google/go-github/v48/github"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"testing"
 
-	gogithub "github.com/google/go-github/v47/github"
+	gogithub "github.com/google/go-github/v48/github"
 	"github.com/stretchr/testify/require"
 
 	"sigs.k8s.io/release-sdk/git"

--- a/github/githubfakes/fake_client.go
+++ b/github/githubfakes/fake_client.go
@@ -23,7 +23,7 @@ import (
 	"os"
 	"sync"
 
-	githuba "github.com/google/go-github/v47/github"
+	githuba "github.com/google/go-github/v48/github"
 	"sigs.k8s.io/release-sdk/github"
 )
 

--- a/github/internal/retry.go
+++ b/github/internal/retry.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v47/github"
+	"github.com/google/go-github/v48/github"
 	"github.com/sirupsen/logrus"
 )
 

--- a/github/internal/retry_test.go
+++ b/github/internal/retry_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v47/github"
+	"github.com/google/go-github/v48/github"
 	"github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/release-sdk/github/internal"

--- a/github/record.go
+++ b/github/record.go
@@ -26,7 +26,7 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/google/go-github/v47/github"
+	"github.com/google/go-github/v48/github"
 	"github.com/sirupsen/logrus"
 )
 

--- a/github/replay.go
+++ b/github/replay.go
@@ -25,7 +25,7 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/google/go-github/v47/github"
+	"github.com/google/go-github/v48/github"
 )
 
 func NewReplayer(replayDir string) Client {

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/carolynvs/magex v0.9.0
 	github.com/go-git/go-git/v5 v5.5.1
 	github.com/google/go-containerregistry v0.12.1
-	github.com/google/go-github/v47 v47.1.0
+	github.com/google/go-github/v48 v48.2.0
 	github.com/jellydator/ttlcache/v3 v3.0.0
 	github.com/magefile/mage v1.14.0
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.5.0

--- a/go.sum
+++ b/go.sum
@@ -718,8 +718,8 @@ github.com/google/go-containerregistry v0.12.1/go.mod h1:sdIK+oHQO7B93xI8UweYdl8
 github.com/google/go-github/v28 v28.1.1/go.mod h1:bsqJWQX05omyWVmc00nEUql9mhQyv38lDZ8kPZcQVoM=
 github.com/google/go-github/v45 v45.2.0 h1:5oRLszbrkvxDDqBCNj2hjDZMKmvexaZ1xw/FCD+K3FI=
 github.com/google/go-github/v45 v45.2.0/go.mod h1:FObaZJEDSTa/WGCzZ2Z3eoCDXWJKMenWWTrd8jrta28=
-github.com/google/go-github/v47 v47.1.0 h1:Cacm/WxQBOa9lF0FT0EMjZ2BWMetQ1TQfyurn4yF1z8=
-github.com/google/go-github/v47 v47.1.0/go.mod h1:VPZBXNbFSJGjyjFRUKo9vZGawTajnWzC/YjGw/oFKi0=
+github.com/google/go-github/v48 v48.2.0 h1:68puzySE6WqUY9KWmpOsDEQfDZsso98rT6pZcz9HqcE=
+github.com/google/go-github/v48 v48.2.0/go.mod h1:dDlehKBDo850ZPvCTK0sEqTCVWcrGl2LcDiajkYi89Y=
 github.com/google/go-licenses v0.0.0-20210329231322-ce1d9163b77d/go.mod h1:+TYOmkVoJOpwnS0wfdsJCV9CoD5nJYsHoFk/0CrTK4M=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

I noticed while trying to leverage this package downstream (https://github.com/uwu-tools/gh-jira-issue-sync/issues/57, https://github.com/uwu-tools/gh-jira-issue-sync/pull/58) that I had to downgrade the tool's go-github version.

Let's update the go-github dep to https://github.com/google/go-github/releases/tag/v48.2.0, which also happens be their first release to support GitHub's new calendar-based API versions (https://github.com/google/go-github/pull/2581, https://github.com/google/go-github/issues/2580, https://github.blog/2022-11-28-to-infinity-and-beyond-enabling-the-future-of-githubs-rest-api-with-api-versioning/)

/assign @saschagrunert @Verolop @puerco @cpanato 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
