### PR TITLE
github: Add `ListComments` method

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/google/go-github/v48/github"
 	"github.com/sirupsen/logrus"
@@ -146,6 +147,9 @@ type Client interface {
 	ListIssues(
 		context.Context, string, string, *github.IssueListByRepoOptions,
 	) ([]*github.Issue, *github.Response, error)
+	ListComments(
+		context.Context, string, string, int, *github.IssueListCommentsOptions,
+	) ([]*github.IssueComment, *github.Response, error)
 }
 
 // NewIssueOptions is a struct of optional fields for new issues
@@ -490,6 +494,20 @@ func (g *githubClient) ListIssues(
 	}
 
 	return issues, response, nil
+}
+
+func (g *githubClient) ListComments(
+	ctx context.Context,
+	owner, repo string,
+	number int,
+	opts *github.IssueListCommentsOptions,
+) ([]*github.IssueComment, *github.Response, error) {
+	comments, response, err := g.Issues.ListComments(ctx, owner, repo, number, opts)
+	if err != nil {
+		return nil, nil, fmt.Errorf("fetching comments from issue: %w", err)
+	}
+
+	return comments, response, nil
 }
 
 // SetClient can be used to manually set the internal GitHub client
@@ -1098,4 +1116,56 @@ func (g *GitHub) ListIssues(owner, repo string, state IssueState) ([]*github.Iss
 	}
 
 	return issues, nil
+}
+
+// Sort specifies how to sort comments. Possible values are: created, updated.
+type Sort string
+
+// SortDirection in which to sort comments. Possible values are: asc, desc.
+type SortDirection string
+
+const (
+	SortCreated Sort = "created"
+	SortUpdated Sort = "updated"
+
+	SortDirectionAscending  SortDirection = "asc"
+	SortDirectionDescending SortDirection = "desc"
+)
+
+// ListComments lists all comments on the specified issue. Specifying an issue
+// number of 0 will return all comments on all issues for the repository.
+//
+// GitHub API docs: https://docs.github.com/en/rest/issues/comments#list-issue-comments
+// GitHub API docs: https://docs.github.com/en/rest/issues/comments#list-issue-comments-for-a-repository
+func (g *GitHub) ListComments(
+	owner, repo string,
+	issueNumber int,
+	sort Sort,
+	direction SortDirection,
+	since *time.Time,
+) ([]*github.IssueComment, error) {
+	options := &github.IssueListCommentsOptions{
+		Sort:        github.String(string(sort)),
+		Direction:   github.String(string(direction)),
+		ListOptions: github.ListOptions{PerPage: g.Options().GetItemsPerPage()},
+	}
+
+	if since != nil {
+		options.Since = since
+	}
+
+	comments := []*github.IssueComment{}
+	for {
+		more, r, err := g.Client().ListComments(context.Background(), owner, repo, issueNumber, options)
+		if err != nil {
+			return comments, fmt.Errorf("getting comments from client: %w", err)
+		}
+		comments = append(comments, more...)
+		if r.NextPage == 0 {
+			break
+		}
+		options.Page = r.NextPage
+	}
+
+	return comments, nil
 }

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	gogithub "github.com/google/go-github/v48/github"
 	"github.com/stretchr/testify/require"
@@ -613,4 +614,40 @@ func TestListIssues(t *testing.T) {
 	require.Equal(t, result[0].GetTitle(), issue0)
 	require.Equal(t, result[1].GetTitle(), issue1)
 	require.Equal(t, result[2].GetTitle(), issue2)
+}
+
+func TestListComments(t *testing.T) {
+	// Given
+	sut, client := newSUT()
+
+	comment0 := "comment 0"
+	comment1 := "comment 1"
+	comment2 := "comment 2"
+
+	comments := []*gogithub.IssueComment{
+		{Body: &comment0},
+		{Body: &comment1},
+		{Body: &comment2},
+	}
+
+	client.ListCommentsReturns(comments, &gogithub.Response{NextPage: 0}, nil)
+
+	since := time.Now()
+
+	// When
+	result, err := sut.ListComments(
+		"fake-owner",
+		"fake-repo",
+		1,
+		github.SortCreated,
+		github.SortDirectionAscending,
+		&since,
+	)
+
+	// Then
+	require.Nil(t, err)
+	require.Len(t, result, 3)
+	require.Equal(t, result[0].GetBody(), comment0)
+	require.Equal(t, result[1].GetBody(), comment1)
+	require.Equal(t, result[2].GetBody(), comment2)
 }

--- a/github/githubfakes/fake_client.go
+++ b/github/githubfakes/fake_client.go
@@ -258,6 +258,25 @@ type FakeClient struct {
 		result2 *githuba.Response
 		result3 error
 	}
+	ListCommentsStub        func(context.Context, string, string, int, *githuba.IssueListCommentsOptions) ([]*githuba.IssueComment, *githuba.Response, error)
+	listCommentsMutex       sync.RWMutex
+	listCommentsArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 int
+		arg5 *githuba.IssueListCommentsOptions
+	}
+	listCommentsReturns struct {
+		result1 []*githuba.IssueComment
+		result2 *githuba.Response
+		result3 error
+	}
+	listCommentsReturnsOnCall map[int]struct {
+		result1 []*githuba.IssueComment
+		result2 *githuba.Response
+		result3 error
+	}
 	ListCommitsStub        func(context.Context, string, string, *githuba.CommitsListOptions) ([]*githuba.RepositoryCommit, *githuba.Response, error)
 	listCommitsMutex       sync.RWMutex
 	listCommitsArgsForCall []struct {
@@ -1349,6 +1368,77 @@ func (fake *FakeClient) ListBranchesReturnsOnCall(i int, result1 []*githuba.Bran
 	}{result1, result2, result3}
 }
 
+func (fake *FakeClient) ListComments(arg1 context.Context, arg2 string, arg3 string, arg4 int, arg5 *githuba.IssueListCommentsOptions) ([]*githuba.IssueComment, *githuba.Response, error) {
+	fake.listCommentsMutex.Lock()
+	ret, specificReturn := fake.listCommentsReturnsOnCall[len(fake.listCommentsArgsForCall)]
+	fake.listCommentsArgsForCall = append(fake.listCommentsArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 int
+		arg5 *githuba.IssueListCommentsOptions
+	}{arg1, arg2, arg3, arg4, arg5})
+	stub := fake.ListCommentsStub
+	fakeReturns := fake.listCommentsReturns
+	fake.recordInvocation("ListComments", []interface{}{arg1, arg2, arg3, arg4, arg5})
+	fake.listCommentsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeClient) ListCommentsCallCount() int {
+	fake.listCommentsMutex.RLock()
+	defer fake.listCommentsMutex.RUnlock()
+	return len(fake.listCommentsArgsForCall)
+}
+
+func (fake *FakeClient) ListCommentsCalls(stub func(context.Context, string, string, int, *githuba.IssueListCommentsOptions) ([]*githuba.IssueComment, *githuba.Response, error)) {
+	fake.listCommentsMutex.Lock()
+	defer fake.listCommentsMutex.Unlock()
+	fake.ListCommentsStub = stub
+}
+
+func (fake *FakeClient) ListCommentsArgsForCall(i int) (context.Context, string, string, int, *githuba.IssueListCommentsOptions) {
+	fake.listCommentsMutex.RLock()
+	defer fake.listCommentsMutex.RUnlock()
+	argsForCall := fake.listCommentsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
+}
+
+func (fake *FakeClient) ListCommentsReturns(result1 []*githuba.IssueComment, result2 *githuba.Response, result3 error) {
+	fake.listCommentsMutex.Lock()
+	defer fake.listCommentsMutex.Unlock()
+	fake.ListCommentsStub = nil
+	fake.listCommentsReturns = struct {
+		result1 []*githuba.IssueComment
+		result2 *githuba.Response
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeClient) ListCommentsReturnsOnCall(i int, result1 []*githuba.IssueComment, result2 *githuba.Response, result3 error) {
+	fake.listCommentsMutex.Lock()
+	defer fake.listCommentsMutex.Unlock()
+	fake.ListCommentsStub = nil
+	if fake.listCommentsReturnsOnCall == nil {
+		fake.listCommentsReturnsOnCall = make(map[int]struct {
+			result1 []*githuba.IssueComment
+			result2 *githuba.Response
+			result3 error
+		})
+	}
+	fake.listCommentsReturnsOnCall[i] = struct {
+		result1 []*githuba.IssueComment
+		result2 *githuba.Response
+		result3 error
+	}{result1, result2, result3}
+}
+
 func (fake *FakeClient) ListCommits(arg1 context.Context, arg2 string, arg3 string, arg4 *githuba.CommitsListOptions) ([]*githuba.RepositoryCommit, *githuba.Response, error) {
 	fake.listCommitsMutex.Lock()
 	ret, specificReturn := fake.listCommitsReturnsOnCall[len(fake.listCommitsArgsForCall)]
@@ -2075,6 +2165,8 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.getRepositoryMutex.RUnlock()
 	fake.listBranchesMutex.RLock()
 	defer fake.listBranchesMutex.RUnlock()
+	fake.listCommentsMutex.RLock()
+	defer fake.listCommentsMutex.RUnlock()
 	fake.listCommitsMutex.RLock()
 	defer fake.listCommitsMutex.RUnlock()
 	fake.listIssuesMutex.RLock()

--- a/github/record.go
+++ b/github/record.go
@@ -50,6 +50,7 @@ const (
 	gitHubAPICreateComment              gitHubAPI = "CreateComment"
 	gitHubAPIListMilestones             gitHubAPI = "ListMilestones"
 	gitHubAPIListIssues                 gitHubAPI = "ListIssues"
+	gitHubAPIListComments               gitHubAPI = "ListComments"
 )
 
 type apiRecord struct {
@@ -323,6 +324,19 @@ func (c *githubNotesRecordClient) ListIssues(
 		return nil, nil, err
 	}
 	return issues, resp, nil
+}
+
+func (c *githubNotesRecordClient) ListComments(
+	ctx context.Context, owner, repo string, number int, opts *github.IssueListCommentsOptions,
+) ([]*github.IssueComment, *github.Response, error) {
+	comments, resp, err := c.client.ListComments(ctx, owner, repo, number, opts)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := c.recordAPICall(gitHubAPIListComments, comments, resp); err != nil {
+		return nil, nil, err
+	}
+	return comments, resp, nil
 }
 
 // recordAPICall records a single GitHub API call into a JSON file by ensuring

--- a/github/replay.go
+++ b/github/replay.go
@@ -336,3 +336,18 @@ func (c *githubNotesReplayClient) ListIssues(
 	}
 	return issues, record.response(), nil
 }
+
+func (c *githubNotesReplayClient) ListComments(
+	ctx context.Context, owner, repo string, number int, opts *github.IssueListCommentsOptions,
+) ([]*github.IssueComment, *github.Response, error) {
+	data, err := c.readRecordedData(gitHubAPIListComments)
+	if err != nil {
+		return nil, nil, err
+	}
+	comments := make([]*github.IssueComment, 0)
+	record := apiRecord{Result: comments}
+	if err := json.Unmarshal(data, &record); err != nil {
+		return nil, nil, err
+	}
+	return comments, record.response(), nil
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

github: Add `ListComments` method

More stuff I need for https://github.com/uwu-tools/gh-jira-issue-sync/issues/57. 😛 
(Follow-up to https://github.com/kubernetes-sigs/release-sdk/pull/147.)

Signed-off-by: Stephen Augustus <foo@auggie.dev>

/assign @Verolop @puerco @cpanato @xmudrii 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
github: Add `ListComments` method
```
