### PR TITLE
Allow `main` to be a release branch

### DIFF
--- a/regex/regex.go
+++ b/regex/regex.go
@@ -20,7 +20,7 @@ import (
 	"regexp"
 )
 
-const branchRegexStr = `master|release-(\d+)\.(\d+)(\.(\d+))*$`
+const branchRegexStr = `master|main|release-(\d+)\.(\d+)(\.(\d+))*$`
 
 // BranchRegex returns a *regexp.Regexp which evaluates the structure of a
 // Kubernetes release branch


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
Every method using the `BranchRegex` will fail if the default branch is `main`, which is a valid release branch considering it has been renamed from `master`.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Allow `main` to be a valid release branch for `regex.BranchRegex` (used via `git.IsReleaseBranch(string)`).
```
