### PR TITLE
Add `sign.Options.Recursive` config

### DIFF
--- a/sign/options.go
+++ b/sign/options.go
@@ -78,6 +78,10 @@ type Options struct {
 	// MaxCacheItems is the maximumg amount of items the internal caches can hold.
 	// Defaults to 10000.
 	MaxCacheItems uint64
+
+	// If a multi-arch image is specified, additionally sign each discrete image.
+	// Defaults to false.
+	Recursive bool
 }
 
 // Default returns a default Options instance.

--- a/sign/sign.go
+++ b/sign/sign.go
@@ -128,6 +128,7 @@ func (s *Signer) SignImageWithOptions(options *Options, reference string) (objec
 	if err := options.verifySignOptions(); err != nil {
 		return nil, fmt.Errorf("checking signing options: %w", err)
 	}
+	s.log().Debugf("Using options: %+v", options)
 
 	resetFn, err := s.enableExperimental()
 	if err != nil {
@@ -175,7 +176,7 @@ func (s *Signer) SignImageWithOptions(options *Options, reference string) (objec
 	if err := s.impl.SignImageInternal(
 		options.ToCosignRootOptions(), ko, regOpts, options.Annotations,
 		images, "", options.AttachSignature, options.OutputSignaturePath,
-		options.OutputCertificatePath, "", true, false, "", false,
+		options.OutputCertificatePath, "", true, options.Recursive, "", false,
 	); err != nil {
 		return nil, fmt.Errorf("sign reference: %s: %w", reference, err)
 	}


### PR DESCRIPTION



#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
This allows signing multi-arch images together with their discrete entities.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
PTAL @kubernetes-sigs/release-engineering 
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `Recursive` option to sign package to be able to sign multi-arch images containing their discrete images.
```
