### PR TITLE
Upload signatures to transparency log

### DIFF
--- a/sign/sign.go
+++ b/sign/sign.go
@@ -154,12 +154,13 @@ func (s *Signer) SignImageWithOptions(options *Options, reference string) (objec
 	}
 
 	ko := cliOpts.KeyOpts{
-		KeyRef:     options.PrivateKeyPath,
-		IDToken:    identityToken,
-		PassFunc:   options.PassFunc,
-		FulcioURL:  cliOpts.DefaultFulcioURL,
-		RekorURL:   cliOpts.DefaultRekorURL,
-		OIDCIssuer: cliOpts.DefaultOIDCIssuerURL,
+		KeyRef:           options.PrivateKeyPath,
+		IDToken:          identityToken,
+		PassFunc:         options.PassFunc,
+		FulcioURL:        cliOpts.DefaultFulcioURL,
+		RekorURL:         cliOpts.DefaultRekorURL,
+		OIDCIssuer:       cliOpts.DefaultOIDCIssuerURL,
+		SkipConfirmation: true,
 
 		InsecureSkipFulcioVerify: false,
 	}
@@ -169,7 +170,7 @@ func (s *Signer) SignImageWithOptions(options *Options, reference string) (objec
 		OutputCertificate: options.OutputCertificatePath,
 		Upload:            true,
 		Recursive:         options.Recursive,
-		TlogUpload:        false,
+		TlogUpload:        true,
 		AnnotationOptions: cliOpts.AnnotationOptions{
 			Annotations: options.Annotations,
 		},
@@ -258,7 +259,7 @@ func (s *Signer) SignFile(path string) (*SignedObject, error) {
 
 	if err := s.impl.SignFileInternal(
 		s.options.ToCosignRootOptions(), ko, path, true,
-		s.options.OutputSignaturePath, s.options.OutputCertificatePath, false,
+		s.options.OutputSignaturePath, s.options.OutputCertificatePath, true,
 	); err != nil {
 		return nil, fmt.Errorf("sign file: %s: %w", path, err)
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind regression

#### What this PR does / why we need it:

Images signed with krel are failing verification. This can be observed in build-master job: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/ci-kubernetes-build/1661016905332297728

```
level=fatal msg="failed to run: push container images: publish container images: get manifest images: traversing path: executing tarball callback: sign container image: retrying image verification: timed out waiting for the condition"
```

I tried running following two commands locally:

```
cosign verify gcr.io/k8s-staging-ci-images/conformance-amd64:v1.28.0-alpha.0.1136_61d455ed1173cd --certificate-identity=prow-build@k8s-infra-prow-build.iam.gserviceaccount.com --certificate-oidc-issuer=https://accounts.google.com

cosign verify gcr.io/k8s-staging-ci-images/conformance-amd64:v1.28.0-alpha.0.1136_61d455ed1173cd --certificate-identity-regexp='.*' --certificate-oidc-issuer-regexp='.*'
```

Both commands are returning the following error:

```
Error: no matching signatures:
signature not found in transparency log
main.go:69: error during command execution: no matching signatures:
signature not found in transparency log
```

Looking at logs for the job, the image is signed. I also verified this by checking if the signature is pushed to the registry and it is.

```
# crane digest gcr.io/k8s-staging-ci-images/conformance-amd64:v1.28.0-alpha.0.1136_61d455ed1173cd
sha256:41a10d692d0b329d721a09e564f26291d90fbcf9425fc4f609645cde7ce54036

# crane digest gcr.io/k8s-staging-ci-images/conformance-amd64:sha256-41a10d692d0b329d721a09e564f26291d90fbcf9425fc4f609645cde7ce54036.sig
sha256:84dc96359db3b4f558208ecaf84a121458530632e9fc73059c5bb7ba58dd7b57
```

Given the error shared above, I think we need to upload signatures to the transparency log which we're not doing right now. This PR proposes doing this both for images and files.

#### Which issue(s) this PR fixes:

None

#### Does this PR introduce a user-facing change?
```release-note
NONE
```

/assign @cpanato @saschagrunert 
cc @kubernetes-sigs/release-engineering