### PR TITLE
Default CertIdentityRegexp and CertOidcIssuer in SignOptions

### DIFF
--- a/sign/options.go
+++ b/sign/options.go
@@ -101,6 +101,8 @@ func Default() *Options {
 		MaxWorkers:           100,
 		CacheTimeout:         2 * time.Hour,
 		MaxCacheItems:        10000,
+		CertIdentityRegexp:   "(prow-build@k8s-infra-prow-build.iam.gserviceaccount.com)|((krel-trust|krel-staging)@k8s-releng-prod.iam.gserviceaccount.com)",
+		CertOidcIssuer:       "https://accounts.google.com",
 	}
 }
 

--- a/test/integration/sign_test.go
+++ b/test/integration/sign_test.go
@@ -268,6 +268,7 @@ func TestVerifyImages(t *testing.T) {
 			opts := sign.Default()
 			opts.CertIdentity = tc.certIdentity
 			opts.CertOidcIssuer = tc.certOidcIssuer
+			opts.CertIdentityRegexp = ""
 			opts.IgnoreSCT = true
 
 			signer := sign.New(opts)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- Default CertIdentityRegexp to `(prow-build@k8s-infra-prow-build.iam.gserviceaccount.com)|((krel-trust|krel-staging)@k8s-releng-prod.iam.gserviceaccount.com)` in default signer options
- Default CertOidcIssuer to `https://accounts.google.com/` in default signer options

Those two options/flags are required now that we use cosign v2. Identity should always be the same, and issue should match all identities that we use currently.

#### Which issue(s) this PR fixes:

None

#### Does this PR introduce a user-facing change?
```release-note
- Default CertIdentityRegexp to `(prow-build@k8s-infra-prow-build.iam.gserviceaccount.com)|((krel-trust|krel-staging)@k8s-releng-prod.iam.gserviceaccount.com)` in default signer options
- Default CertOidcIssuer to `https://accounts.google.com/` in default signer options
```

/assign @saschagrunert @cpanato 
cc @kubernetes-sigs/release-engineering 