### PR TITLE
Add osc package for running osc tool

### DIFF
--- a/osc/auth.go
+++ b/osc/auth.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package osc
+
+import (
+	"fmt"
+	"os"
+)
+
+const (
+	authFileFormat = `
+[general]
+apiurl = %s
+
+[%s]
+user=%s
+pass=%s
+credentials_mgr_class=osc.credentials.PlaintextConfigFileCredentialsManager
+`
+
+	oscConfigFilePath = "/root/.oscrc"
+)
+
+// CreateOSCConfigFile creates the osc config file (~/.oscrc) that contains
+// API URL and credentials needed to authenticate with the API
+func CreateOSCConfigFile(apiURL, username, password string) error {
+	authFile := fmt.Sprintf(authFileFormat, apiURL, apiURL, username, password)
+
+	if err := os.WriteFile(oscConfigFilePath, []byte(authFile), 0600); err != nil {
+		return fmt.Errorf("writing osc config file: %w", err)
+	}
+
+	return nil
+}

--- a/osc/config.go
+++ b/osc/config.go
@@ -19,6 +19,7 @@ package osc
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 )
 
 const (
@@ -31,13 +32,17 @@ user=%s
 pass=%s
 credentials_mgr_class=osc.credentials.PlaintextConfigFileCredentialsManager
 `
-
-	oscConfigFilePath = "/root/.oscrc"
 )
 
 // CreateOSCConfigFile creates the osc config file (~/.oscrc) that contains
 // API URL and credentials needed to authenticate with the API
 func CreateOSCConfigFile(apiURL, username, password string) error {
+	userHome, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("obtaining user's home directory: %w", err)
+	}
+
+	oscConfigFilePath := filepath.Join(userHome, ".oscrc")
 	authFile := fmt.Sprintf(authFileFormat, apiURL, apiURL, username, password)
 
 	if err := os.WriteFile(oscConfigFilePath, []byte(authFile), 0o600); err != nil {

--- a/osc/config.go
+++ b/osc/config.go
@@ -40,7 +40,7 @@ credentials_mgr_class=osc.credentials.PlaintextConfigFileCredentialsManager
 func CreateOSCConfigFile(apiURL, username, password string) error {
 	authFile := fmt.Sprintf(authFileFormat, apiURL, apiURL, username, password)
 
-	if err := os.WriteFile(oscConfigFilePath, []byte(authFile), 0600); err != nil {
+	if err := os.WriteFile(oscConfigFilePath, []byte(authFile), 0o600); err != nil {
 		return fmt.Errorf("writing osc config file: %w", err)
 	}
 

--- a/osc/osc.go
+++ b/osc/osc.go
@@ -48,7 +48,7 @@ func OSC(args ...string) error {
 	return command.New(OSCExecutable, args...).RunSilentSuccess()
 }
 
-func OSCWithWorkDir(workDir string, args ...string) error {
+func WithWorkDir(workDir string, args ...string) error {
 	return command.NewWithWorkDir(workDir, OSCExecutable, args...).RunSilentSuccess()
 }
 

--- a/osc/osc.go
+++ b/osc/osc.go
@@ -48,6 +48,10 @@ func OSC(args ...string) error {
 	return command.New(OSCExecutable, args...).RunSilentSuccess()
 }
 
+func OSCWithWorkDir(workDir string, args ...string) error {
+	return command.NewWithWorkDir(workDir, OSCExecutable, args...).RunSilentSuccess()
+}
+
 // Output can be used to run a 'osc' command while capturing its output
 func Output(args ...string) (string, error) {
 	stream, err := command.New(OSCExecutable, args...).RunSilentSuccessOutput()

--- a/osc/osc.go
+++ b/osc/osc.go
@@ -48,8 +48,8 @@ func OSC(args ...string) error {
 	return command.New(OSCExecutable, args...).RunSilentSuccess()
 }
 
-// OSCOutput can be used to run a 'osc' command while capturing its output
-func OSCOutput(args ...string) (string, error) {
+// Output can be used to run a 'osc' command while capturing its output
+func Output(args ...string) (string, error) {
 	stream, err := command.New(OSCExecutable, args...).RunSilentSuccessOutput()
 	if err != nil {
 		return "", fmt.Errorf("executing %s: %w", OSCExecutable, err)
@@ -57,7 +57,7 @@ func OSCOutput(args ...string) (string, error) {
 	return stream.OutputTrimNL(), nil
 }
 
-// GSUtilStatus can be used to run a 'osc' command while capturing its status
-func OSCStatus(args ...string) (*command.Status, error) {
+// Status can be used to run a 'osc' command while capturing its status
+func Status(args ...string) (*command.Status, error) {
 	return command.New(OSCExecutable, args...).Run()
 }

--- a/osc/osc.go
+++ b/osc/osc.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package osc
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/release-utils/command"
+)
+
+const (
+	// OSCExecutable is the name of the OpenBuildService CLI executable
+	OSCExecutable = "osc"
+)
+
+// PreCheck checks if all requirements are fulfilled to run this package and
+// all sub-packages
+func PreCheck() error {
+	for _, e := range []string{
+		OSCExecutable,
+	} {
+		if !command.Available(e) {
+			return fmt.Errorf(
+				"%s executable is not available in $PATH", e,
+			)
+		}
+	}
+
+	return nil
+}
+
+// OSC can be used to run a 'osc' command
+func OSC(args ...string) error {
+	return command.New(OSCExecutable, args...).RunSilentSuccess()
+}
+
+// OSCOutput can be used to run a 'osc' command while capturing its output
+func OSCOutput(args ...string) (string, error) {
+	stream, err := command.New(OSCExecutable, args...).RunSilentSuccessOutput()
+	if err != nil {
+		return "", fmt.Errorf("executing %s: %w", OSCExecutable, err)
+	}
+	return stream.OutputTrimNL(), nil
+}
+
+// GSUtilStatus can be used to run a 'osc' command while capturing its status
+func OSCStatus(args ...string) (*command.Status, error) {
+	return command.New(OSCExecutable, args...).Run()
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds `osc` package for running the `osc` tool (OpenBuildService CLI). We'll eventually capture commands that we use and create functions for each command, but for now, this approach should be good enough.

#### Does this PR introduce a user-facing change?
```release-note
Add `osc` package for running OpenBuildService CLI
```

cc @kubernetes-sigs/release-engineering 