### PR TITLE
Make osc functions take working directory

### DIFF
--- a/osc/osc.go
+++ b/osc/osc.go
@@ -44,17 +44,13 @@ func PreCheck() error {
 }
 
 // OSC can be used to run a 'osc' command
-func OSC(args ...string) error {
-	return command.New(OSCExecutable, args...).RunSilentSuccess()
-}
-
-func WithWorkDir(workDir string, args ...string) error {
+func OSC(workDir string, args ...string) error {
 	return command.NewWithWorkDir(workDir, OSCExecutable, args...).RunSilentSuccess()
 }
 
 // Output can be used to run a 'osc' command while capturing its output
-func Output(args ...string) (string, error) {
-	stream, err := command.New(OSCExecutable, args...).RunSilentSuccessOutput()
+func Output(workDir string, args ...string) (string, error) {
+	stream, err := command.NewWithWorkDir(workDir, OSCExecutable, args...).RunSilentSuccessOutput()
 	if err != nil {
 		return "", fmt.Errorf("executing %s: %w", OSCExecutable, err)
 	}
@@ -62,6 +58,6 @@ func Output(args ...string) (string, error) {
 }
 
 // Status can be used to run a 'osc' command while capturing its status
-func Status(args ...string) (*command.Status, error) {
-	return command.New(OSCExecutable, args...).Run()
+func Status(workDir string, args ...string) (*command.Status, error) {
+	return command.NewWithWorkDir(workDir, OSCExecutable, args...).Run()
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

`osc` calls must be executed in the specific project or package directory. That said, let's make this explicit and make functions in the `osc` package take working directory.

#### Does this PR introduce a user-facing change?
```release-note
Change functions in `osc` package to take the working directory
```

/assign @saschagrunert @cpanato 
cc @kubernetes-sigs/release-engineering 