### PR TITLE
update go-github to v55

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -27,7 +27,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v53/github"
+	"github.com/google/go-github/v55/github"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 
@@ -94,7 +94,7 @@ type Client interface {
 		context.Context, string, string, *github.CommitsListOptions,
 	) ([]*github.RepositoryCommit, *github.Response, error)
 	ListPullRequestsWithCommit(
-		context.Context, string, string, string, *github.PullRequestListOptions,
+		context.Context, string, string, string, *github.ListOptions,
 	) ([]*github.PullRequest, *github.Response, error)
 	ListMilestones(
 		context.Context, string, string, *github.MilestoneListOptions,
@@ -214,7 +214,7 @@ func NewEnterpriseWithToken(baseURL, uploadURL, token string) (*GitHub, error) {
 		))
 	}
 	logrus.Debugf("Using %s Enterprise GitHub client", state)
-	ghclient, err := github.NewEnterpriseClient(baseURL, uploadURL, client)
+	ghclient, err := github.NewClient(client).WithEnterpriseURLs(baseURL, uploadURL)
 	if err != nil {
 		return nil, fmt.Errorf("failed to new github client: %s", err)
 	}
@@ -281,7 +281,7 @@ func (g *githubClient) ListCommits(
 
 func (g *githubClient) ListPullRequestsWithCommit(
 	ctx context.Context, owner, repo, sha string,
-	opt *github.PullRequestListOptions,
+	opt *github.ListOptions,
 ) ([]*github.PullRequest, *github.Response, error) {
 	for shouldRetry := internal.DefaultGithubErrChecker(); ; {
 		prs, resp, err := g.PullRequests.ListPullRequestsWithCommit(

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	gogithub "github.com/google/go-github/v53/github"
+	gogithub "github.com/google/go-github/v55/github"
 	"github.com/stretchr/testify/require"
 
 	"sigs.k8s.io/release-sdk/git"

--- a/github/githubfakes/fake_client.go
+++ b/github/githubfakes/fake_client.go
@@ -23,7 +23,7 @@ import (
 	"os"
 	"sync"
 
-	githuba "github.com/google/go-github/v53/github"
+	githuba "github.com/google/go-github/v55/github"
 	"sigs.k8s.io/release-sdk/github"
 )
 
@@ -331,14 +331,14 @@ type FakeClient struct {
 		result2 *githuba.Response
 		result3 error
 	}
-	ListPullRequestsWithCommitStub        func(context.Context, string, string, string, *githuba.PullRequestListOptions) ([]*githuba.PullRequest, *githuba.Response, error)
+	ListPullRequestsWithCommitStub        func(context.Context, string, string, string, *githuba.ListOptions) ([]*githuba.PullRequest, *githuba.Response, error)
 	listPullRequestsWithCommitMutex       sync.RWMutex
 	listPullRequestsWithCommitArgsForCall []struct {
 		arg1 context.Context
 		arg2 string
 		arg3 string
 		arg4 string
-		arg5 *githuba.PullRequestListOptions
+		arg5 *githuba.ListOptions
 	}
 	listPullRequestsWithCommitReturns struct {
 		result1 []*githuba.PullRequest
@@ -1649,7 +1649,7 @@ func (fake *FakeClient) ListMilestonesReturnsOnCall(i int, result1 []*githuba.Mi
 	}{result1, result2, result3}
 }
 
-func (fake *FakeClient) ListPullRequestsWithCommit(arg1 context.Context, arg2 string, arg3 string, arg4 string, arg5 *githuba.PullRequestListOptions) ([]*githuba.PullRequest, *githuba.Response, error) {
+func (fake *FakeClient) ListPullRequestsWithCommit(arg1 context.Context, arg2 string, arg3 string, arg4 string, arg5 *githuba.ListOptions) ([]*githuba.PullRequest, *githuba.Response, error) {
 	fake.listPullRequestsWithCommitMutex.Lock()
 	ret, specificReturn := fake.listPullRequestsWithCommitReturnsOnCall[len(fake.listPullRequestsWithCommitArgsForCall)]
 	fake.listPullRequestsWithCommitArgsForCall = append(fake.listPullRequestsWithCommitArgsForCall, struct {
@@ -1657,7 +1657,7 @@ func (fake *FakeClient) ListPullRequestsWithCommit(arg1 context.Context, arg2 st
 		arg2 string
 		arg3 string
 		arg4 string
-		arg5 *githuba.PullRequestListOptions
+		arg5 *githuba.ListOptions
 	}{arg1, arg2, arg3, arg4, arg5})
 	stub := fake.ListPullRequestsWithCommitStub
 	fakeReturns := fake.listPullRequestsWithCommitReturns
@@ -1678,13 +1678,13 @@ func (fake *FakeClient) ListPullRequestsWithCommitCallCount() int {
 	return len(fake.listPullRequestsWithCommitArgsForCall)
 }
 
-func (fake *FakeClient) ListPullRequestsWithCommitCalls(stub func(context.Context, string, string, string, *githuba.PullRequestListOptions) ([]*githuba.PullRequest, *githuba.Response, error)) {
+func (fake *FakeClient) ListPullRequestsWithCommitCalls(stub func(context.Context, string, string, string, *githuba.ListOptions) ([]*githuba.PullRequest, *githuba.Response, error)) {
 	fake.listPullRequestsWithCommitMutex.Lock()
 	defer fake.listPullRequestsWithCommitMutex.Unlock()
 	fake.ListPullRequestsWithCommitStub = stub
 }
 
-func (fake *FakeClient) ListPullRequestsWithCommitArgsForCall(i int) (context.Context, string, string, string, *githuba.PullRequestListOptions) {
+func (fake *FakeClient) ListPullRequestsWithCommitArgsForCall(i int) (context.Context, string, string, string, *githuba.ListOptions) {
 	fake.listPullRequestsWithCommitMutex.RLock()
 	defer fake.listPullRequestsWithCommitMutex.RUnlock()
 	argsForCall := fake.listPullRequestsWithCommitArgsForCall[i]

--- a/github/internal/retry.go
+++ b/github/internal/retry.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/go-github/v53/github"
+	"github.com/google/go-github/v55/github"
 	"github.com/sirupsen/logrus"
 )
 

--- a/github/internal/retry_test.go
+++ b/github/internal/retry_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/v53/github"
+	"github.com/google/go-github/v55/github"
 	"github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/release-sdk/github/internal"

--- a/github/record.go
+++ b/github/record.go
@@ -26,7 +26,7 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/google/go-github/v53/github"
+	"github.com/google/go-github/v55/github"
 	"github.com/sirupsen/logrus"
 )
 
@@ -99,7 +99,7 @@ func (c *githubNotesRecordClient) ListCommits(ctx context.Context, owner, repo s
 	return commits, resp, nil
 }
 
-func (c *githubNotesRecordClient) ListPullRequestsWithCommit(ctx context.Context, owner, repo, sha string, opt *github.PullRequestListOptions) ([]*github.PullRequest, *github.Response, error) {
+func (c *githubNotesRecordClient) ListPullRequestsWithCommit(ctx context.Context, owner, repo, sha string, opt *github.ListOptions) ([]*github.PullRequest, *github.Response, error) {
 	prs, resp, err := c.client.ListPullRequestsWithCommit(ctx, owner, repo, sha, opt)
 	if err != nil {
 		return nil, nil, err

--- a/github/replay.go
+++ b/github/replay.go
@@ -25,7 +25,7 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/google/go-github/v53/github"
+	"github.com/google/go-github/v55/github"
 )
 
 func NewReplayer(replayDir string) Client {
@@ -67,7 +67,7 @@ func (c *githubNotesReplayClient) ListCommits(ctx context.Context, owner, repo s
 	return result, record.response(), nil
 }
 
-func (c *githubNotesReplayClient) ListPullRequestsWithCommit(ctx context.Context, owner, repo, sha string, opt *github.PullRequestListOptions) ([]*github.PullRequest, *github.Response, error) { //nolint: revive
+func (c *githubNotesReplayClient) ListPullRequestsWithCommit(ctx context.Context, owner, repo, sha string, opt *github.ListOptions) ([]*github.PullRequest, *github.Response, error) { //nolint: revive
 	data, err := c.readRecordedData(gitHubAPIListPullRequestsWithCommit)
 	if err != nil {
 		return nil, nil, err

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/go-git/go-git/v5 v5.9.0
 	github.com/google/go-containerregistry v0.16.1
-	github.com/google/go-github/v53 v53.2.0
+	github.com/google/go-github/v55 v55.0.0
 	github.com/jellydator/ttlcache/v3 v3.1.0
 	github.com/magefile/mage v1.15.0
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.7.0
@@ -143,6 +143,7 @@ require (
 	github.com/google/certificate-transparency-go v1.1.6 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
+	github.com/google/go-github/v53 v53.2.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/s2a-go v0.1.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -597,6 +597,8 @@ github.com/google/go-containerregistry v0.16.1 h1:rUEt426sR6nyrL3gt+18ibRcvYpKYd
 github.com/google/go-containerregistry v0.16.1/go.mod h1:u0qB2l7mvtWVR5kNcbFIhFY1hLbf8eeGapA+vbFDCtQ=
 github.com/google/go-github/v53 v53.2.0 h1:wvz3FyF53v4BK+AsnvCmeNhf8AkTaeh2SoYu/XUvTtI=
 github.com/google/go-github/v53 v53.2.0/go.mod h1:XhFRObz+m/l+UCm9b7KSIC3lT3NWSXGt7mOsAWEloao=
+github.com/google/go-github/v55 v55.0.0 h1:4pp/1tNMB9X/LuAhs5i0KQAE40NmiR/y6prLNb9x9cg=
+github.com/google/go-github/v55 v55.0.0/go.mod h1:JLahOTA1DnXzhxEymmFF5PP2tSS9JVNj68mSZNDwskA=
 github.com/google/go-querystring v1.1.0 h1:AnCroh3fv4ZBgVIf1Iwtovgjaw/GiKJo8M8yD/fhyJ8=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind feature


#### What this PR does / why we need it:
- update go-github to v55

/assign @saschagrunert @puerco @Verolop @xmudrii 

cc @kubernetes-sigs/release-engineering 


#### Which issue(s) this PR fixes:


None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
update go-github to v55
```
