### PR TITLE
Add additional method to update GitHub releases with more flexible opts

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -31,6 +31,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/oauth2"
 
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/release-sdk/git"
 	"sigs.k8s.io/release-sdk/github/internal"
 	"sigs.k8s.io/release-utils/env"
@@ -158,6 +159,20 @@ type NewIssueOptions struct {
 	State     string   // open, closed or all. Defaults to "open"
 	Assignees []string // List of GitHub handles of extra assignees, must be collaborators
 	Labels    []string // List of labels to apply. They will be created if new
+}
+
+// UpdateReleasePageOptions is a struct of optional fields for creating/updating releases.
+type UpdateReleasePageOptions struct {
+	// Name is the name/title of the release.
+	Name *string
+	// Body is the body/content of the release (e.g. release notes).
+	Body *string
+	// Draft is marking the release as draft, if set to true.
+	Draft *bool
+	// Prerelease is marking the release as a pre-release, if set to true.
+	Prerelease *bool
+	// Latest is marking the release to be set as latest at the time of updating, if set to true.
+	Latest *bool
 }
 
 // TODO: we should clean up the functions listed below and agree on the same
@@ -962,19 +977,52 @@ func (g *GitHub) UpdateReleasePage(
 	tag, commitish, name, body string,
 	isDraft, isPrerelease bool,
 ) (release *github.RepositoryRelease, err error) {
-	logrus.Infof("Updating release page for %s", tag)
+	return g.UpdateReleasePageWithOptions(owner, repo, releaseID, tag, commitish, &UpdateReleasePageOptions{
+		Name:       &name,
+		Body:       &body,
+		Draft:      &isDraft,
+		Prerelease: &isPrerelease,
+	})
+}
 
-	// Create the options for the
-	releaseData := &github.RepositoryRelease{
-		TagName:         &tag,
-		TargetCommitish: &commitish,
-		Name:            &name,
-		Body:            &body,
-		Draft:           &isDraft,
-		Prerelease:      &isPrerelease,
+// toRepositoryRelease builds a repository release from the set of options.
+func (u *UpdateReleasePageOptions) toRepositoryRelease() *github.RepositoryRelease {
+	request := &github.RepositoryRelease{}
+	request.Name = u.Name
+	request.Body = u.Body
+	request.Draft = u.Draft
+	request.Prerelease = u.Prerelease
+
+	if u.Latest != nil {
+		if *u.Latest {
+			request.MakeLatest = ptr.To("true")
+		} else {
+			request.MakeLatest = ptr.To("false")
+		}
 	}
 
-	// Call the client
+	return request
+}
+
+// UpdateReleasePageWithOptions updates release pages (same as UpdateReleasePage),
+// but does so by taking a UpdateReleasePageOptions parameter. It will _not_ set
+// a release as latest unless the corresponding option is set.
+func (g *GitHub) UpdateReleasePageWithOptions(owner, repo string,
+	releaseID int64,
+	tag, commitish string,
+	opts *UpdateReleasePageOptions,
+) (release *github.RepositoryRelease, err error) {
+	logrus.Infof("Updating release page for %s", tag)
+
+	if opts == nil {
+		opts = &UpdateReleasePageOptions{}
+	}
+
+	releaseData := opts.toRepositoryRelease()
+	releaseData.TagName = &tag
+	releaseData.TargetCommitish = &commitish
+
+	// Call the client.
 	release, err = g.Client().UpdateReleasePage(
 		context.Background(), owner, repo, releaseID, releaseData,
 	)

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/uwu-tools/magex v0.10.0
 	golang.org/x/oauth2 v0.15.0
 	k8s.io/apimachinery v0.29.0
+	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	sigs.k8s.io/release-utils v0.7.7
 )
 
@@ -253,7 +254,6 @@ require (
 	k8s.io/client-go v0.28.3 // indirect
 	k8s.io/klog/v2 v2.110.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 // indirect
-	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds another method to the GitHub client called `UpdateReleasePageWithOptions`. The idea is to move everything that is optional in a release into `UpdateReleasePageOptions`, so that the function signature no longer changes if other fields of a GitHub release need to be set. The field in question in this situation is `MakeLatest`, but I figured it makes sense to copy `NewIssue` behaviour, in case releases gain additional fields/opts in the future.

I am adding this so that `krel` can (once this is available) decide whether a release should be marked as latest or not. This is an issue tracked as https://github.com/kubernetes/kubernetes/issues/119472.

This came out a brief discussion at https://kubernetes.slack.com/archives/C2C40FMNF/p1702501467543419, I hope it understood the consensus there correctly. I'm very much open to feedback since this is my first contribution to release-related tooling in Kubernetes.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

I added a simple test case which I'm not sure is _super_ useful, but there was no existing test case for `UpdateReleasePage`, so maybe we can/should drop the test case. Open to input here.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add `UpdateReleasePageWithOptions` method to the `github` package to add more flexible options when updating releases
```
