### PR TITLE
Publish the marker inside the fast folder

### DIFF
--- a/object/gcs.go
+++ b/object/gcs.go
@@ -212,14 +212,14 @@ func (g *GCS) GetReleasePath(
 //
 //	gs://<bucket>/<gcsRoot>
 func (g *GCS) GetMarkerPath(
-	bucket, gcsRoot string,
+	bucket, gcsRoot string, fast bool,
 ) (string, error) {
 	gcsPath, err := g.getPath(
 		bucket,
 		gcsRoot,
 		"",
 		"marker",
-		false,
+		fast,
 	)
 	if err != nil {
 		return "", fmt.Errorf("normalize GCS path: %w", err)
@@ -258,6 +258,9 @@ func (g *GCS) getPath(
 			gcsPathParts = append(gcsPathParts, version)
 		}
 	case "marker":
+		if fast {
+			gcsPathParts = append(gcsPathParts, "fast")
+		}
 	default:
 		return "", errors.New("a GCS path type must be specified")
 	}

--- a/object/gcs_test.go
+++ b/object/gcs_test.go
@@ -110,24 +110,40 @@ func TestGetMarkerPath(t *testing.T) {
 		bucket, gcsRoot string
 		expected        string
 		shouldError     bool
+		fast            bool
 	}{
 		{ // default CI build
 			bucket:      "k8s-release-dev",
 			gcsRoot:     "ci",
 			expected:    "gs://k8s-release-dev/ci",
 			shouldError: false,
+			fast:        false,
+		},
+		{ // default fast CI build
+			bucket:      "k8s-release-dev",
+			gcsRoot:     "ci",
+			expected:    "gs://k8s-release-dev/ci/fast",
+			shouldError: false,
+			fast:        true,
+		},
+		{ // current problematic behaviour
+			bucket:      "k8s-release-dev",
+			gcsRoot:     "ci",
+			expected:    "gs://k8s-release-dev/ci",
+			shouldError: true,
+			fast:        true,
 		},
 	} {
 		actual, err := testGCS.GetMarkerPath(
 			tc.bucket,
 			tc.gcsRoot,
+			tc.fast,
 		)
 
-		require.Equal(t, tc.expected, actual)
-
 		if tc.shouldError {
-			require.NotNil(t, err)
+			require.NotEqual(t, tc.expected, actual)
 		} else {
+			require.Equal(t, tc.expected, actual)
 			require.Nil(t, err)
 		}
 	}

--- a/object/objectfakes/fake_store.go
+++ b/object/objectfakes/fake_store.go
@@ -334,7 +334,7 @@ func (fake *FakeStore) CopyToRemoteReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeStore) GetMarkerPath(arg1 string, arg2 string) (string, error) {
+func (fake *FakeStore) GetMarkerPath(arg1 string, arg2 string, arg3 bool) (string, error) {
 	fake.getMarkerPathMutex.Lock()
 	ret, specificReturn := fake.getMarkerPathReturnsOnCall[len(fake.getMarkerPathArgsForCall)]
 	fake.getMarkerPathArgsForCall = append(fake.getMarkerPathArgsForCall, struct {

--- a/object/store.go
+++ b/object/store.go
@@ -43,7 +43,7 @@ type Store interface {
 
 	// TODO: Overly specific. We should only care these methods during a release.
 	GetReleasePath(bucket, gcsRoot, version string, fast bool) (string, error)
-	GetMarkerPath(bucket, gcsRoot string) (string, error)
+	GetMarkerPath(bucket, gcsRoot string, fast bool) (string, error)
 }
 
 type OptFn func(Store)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:
fast builds store the marker in `gs://k8s-release-dev/ci/latest-fast.txt` instead of `gs://k8s-release-dev/ci/fast/latest-fast.txt` which is problematic. Look at https://github.com/kubernetes/test-infra/pull/31486 for specific details


#### Which issue(s) this PR fixes:

Part of https://github.com/kubernetes/release/issues/3403

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
breaking change: fast marker (latest-fast.txt) is now stored inside the fast folder instead of the gcsRoot folder(ci)
```
