### PR TITLE
Update preparefork to accept ssh/http option and add new function to push with options

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -310,6 +310,7 @@ type Repository interface {
 	CommitObject(plumbing.Hash) (*object.Commit, error)
 	CreateRemote(*config.RemoteConfig) (*git.Remote, error)
 	DeleteRemote(name string) error
+	Push(o *git.PushOptions) error
 	Head() (*plumbing.Reference, error)
 	Remote(string) (*git.Remote, error)
 	Remotes() ([]*git.Remote, error)
@@ -1340,6 +1341,12 @@ func (r *Repo) PushToRemote(remote, remoteBranch string) error {
 	args = append(args, remote, remoteBranch)
 
 	return filterCommand(r.Dir(), args...).RunSuccess()
+}
+
+// PushToRemote push the current branch to a specified remote, but only if the
+// repository is not in dry run mode
+func (r *Repo) PushToRemoteWithOptions(pushOptions *git.PushOptions) error {
+	return r.inner.Push(pushOptions)
 }
 
 // LsRemote can be used to run `git ls-remote` with the provided args on the

--- a/git/git.go
+++ b/git/git.go
@@ -1321,8 +1321,8 @@ func (r *Repo) HasRemote(name, expectedURL string) bool {
 }
 
 // AddRemote adds a new remote to the current working tree
-func (r *Repo) AddRemote(name, owner, repo string) error {
-	repoURL := GetRepoURL(owner, repo, true)
+func (r *Repo) AddRemote(name, owner, repo string, useSSH bool) error {
+	repoURL := GetRepoURL(owner, repo, useSSH)
 	args := []string{"remote", "add", name, repoURL}
 	return command.
 		NewWithWorkDir(r.Dir(), gitExecutable, args...).

--- a/git/gitfakes/fake_repository.go
+++ b/git/gitfakes/fake_repository.go
@@ -105,6 +105,17 @@ type FakeRepository struct {
 		result1 *plumbing.Reference
 		result2 error
 	}
+	PushStub        func(*gita.PushOptions) error
+	pushMutex       sync.RWMutex
+	pushArgsForCall []struct {
+		arg1 *gita.PushOptions
+	}
+	pushReturns struct {
+		result1 error
+	}
+	pushReturnsOnCall map[int]struct {
+		result1 error
+	}
 	RemoteStub        func(string) (*gita.Remote, error)
 	remoteMutex       sync.RWMutex
 	remoteArgsForCall []struct {
@@ -526,6 +537,67 @@ func (fake *FakeRepository) HeadReturnsOnCall(i int, result1 *plumbing.Reference
 	}{result1, result2}
 }
 
+func (fake *FakeRepository) Push(arg1 *gita.PushOptions) error {
+	fake.pushMutex.Lock()
+	ret, specificReturn := fake.pushReturnsOnCall[len(fake.pushArgsForCall)]
+	fake.pushArgsForCall = append(fake.pushArgsForCall, struct {
+		arg1 *gita.PushOptions
+	}{arg1})
+	stub := fake.PushStub
+	fakeReturns := fake.pushReturns
+	fake.recordInvocation("Push", []interface{}{arg1})
+	fake.pushMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeRepository) PushCallCount() int {
+	fake.pushMutex.RLock()
+	defer fake.pushMutex.RUnlock()
+	return len(fake.pushArgsForCall)
+}
+
+func (fake *FakeRepository) PushCalls(stub func(*gita.PushOptions) error) {
+	fake.pushMutex.Lock()
+	defer fake.pushMutex.Unlock()
+	fake.PushStub = stub
+}
+
+func (fake *FakeRepository) PushArgsForCall(i int) *gita.PushOptions {
+	fake.pushMutex.RLock()
+	defer fake.pushMutex.RUnlock()
+	argsForCall := fake.pushArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeRepository) PushReturns(result1 error) {
+	fake.pushMutex.Lock()
+	defer fake.pushMutex.Unlock()
+	fake.PushStub = nil
+	fake.pushReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeRepository) PushReturnsOnCall(i int, result1 error) {
+	fake.pushMutex.Lock()
+	defer fake.pushMutex.Unlock()
+	fake.PushStub = nil
+	if fake.pushReturnsOnCall == nil {
+		fake.pushReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.pushReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeRepository) Remote(arg1 string) (*gita.Remote, error) {
 	fake.remoteMutex.Lock()
 	ret, specificReturn := fake.remoteReturnsOnCall[len(fake.remoteArgsForCall)]
@@ -781,6 +853,8 @@ func (fake *FakeRepository) Invocations() map[string][][]interface{} {
 	defer fake.deleteRemoteMutex.RUnlock()
 	fake.headMutex.RLock()
 	defer fake.headMutex.RUnlock()
+	fake.pushMutex.RLock()
+	defer fake.pushMutex.RUnlock()
 	fake.remoteMutex.RLock()
 	defer fake.remoteMutex.RUnlock()
 	fake.remotesMutex.RLock()

--- a/github/fork.go
+++ b/github/fork.go
@@ -31,7 +31,7 @@ const (
 )
 
 // PrepareFork prepares a branch from a repo fork
-func PrepareFork(branchName, upstreamOrg, upstreamRepo, myOrg, myRepo string) (repo *git.Repo, err error) {
+func PrepareFork(branchName, upstreamOrg, upstreamRepo, myOrg, myRepo string, useSSH bool) (repo *git.Repo, err error) {
 	// checkout the upstream repository
 	logrus.Infof("Cloning/updating repository %s/%s", upstreamOrg, upstreamRepo)
 
@@ -51,7 +51,7 @@ func PrepareFork(branchName, upstreamOrg, upstreamRepo, myOrg, myRepo string) (r
 		)
 	} else {
 		// add the user's fork as a remote
-		err = repo.AddRemote(UserForkName, myOrg, myRepo)
+		err = repo.AddRemote(UserForkName, myOrg, myRepo, useSSH)
 		if err != nil {
 			return nil, fmt.Errorf("adding user's fork as remote repository: %w", err)
 		}

--- a/test/integration/git_test.go
+++ b/test/integration/git_test.go
@@ -763,7 +763,7 @@ func TestHasRemoteSuccess(t *testing.T) {
 	testRepo := newTestRepo(t)
 	defer testRepo.cleanup(t)
 
-	err := testRepo.sut.AddRemote("test", "owner", "repo")
+	err := testRepo.sut.AddRemote("test", "owner", "repo", true)
 	require.Nil(t, err)
 
 	remotes, err := testRepo.sut.Remotes()
@@ -850,7 +850,7 @@ func TestAddRemoteSuccess(t *testing.T) {
 	testRepo := newTestRepo(t)
 	defer testRepo.cleanup(t)
 
-	err := testRepo.sut.AddRemote("remote", "owner", "repo")
+	err := testRepo.sut.AddRemote("remote", "owner", "repo", true)
 	require.Nil(t, err)
 }
 
@@ -858,7 +858,7 @@ func TestAddRemoteFailureAlreadyExisting(t *testing.T) {
 	testRepo := newTestRepo(t)
 	defer testRepo.cleanup(t)
 
-	err := testRepo.sut.AddRemote(git.DefaultRemote, "owner", "repo")
+	err := testRepo.sut.AddRemote(git.DefaultRemote, "owner", "repo", true)
 	require.NotNil(t, err)
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

- add option to set ssh or http for preparefork
- add push with options for special cases you need to define better the push

#### Which issue(s) this PR fixes:

None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
- add option to set ssh or http for preparefork
- add push with options for special cases you need to define better the push
```
