### PR TITLE
add options to preparefork to when you need to configure special things

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -378,11 +378,11 @@ func CloneOrOpenDefaultGitHubRepoSSH(repoPath string) (*Repo, error) {
 
 // CleanCloneGitHubRepo creates a guaranteed fresh checkout of a given repository. The returned *Repo has a Cleanup()
 // method that should be used to delete the repository on-disk afterwards.
-func CleanCloneGitHubRepo(owner, repo string, useSSH bool) (*Repo, error) {
+func CleanCloneGitHubRepo(owner, repo string, useSSH bool, opts *git.CloneOptions) (*Repo, error) {
 	repoURL := GetRepoURL(owner, repo, useSSH)
 	// The use of a blank string for the repo path triggers special behaviour in CloneOrOpenRepo that causes a true
 	// temporary directory with a random name to be created.
-	return CloneOrOpenRepo("", repoURL, useSSH)
+	return CloneOrOpenRepo("", repoURL, useSSH, opts)
 }
 
 // CloneOrOpenGitHubRepo works with a repository in the given directory, or creates one if the directory is empty. The
@@ -390,7 +390,7 @@ func CleanCloneGitHubRepo(owner, repo string, useSSH bool) (*Repo, error) {
 // repository using the defaultGithubAuthRoot.
 func CloneOrOpenGitHubRepo(repoPath, owner, repo string, useSSH bool) (*Repo, error) {
 	repoURL := GetRepoURL(owner, repo, useSSH)
-	return CloneOrOpenRepo(repoPath, repoURL, useSSH)
+	return CloneOrOpenRepo(repoPath, repoURL, useSSH, nil)
 }
 
 // ShallowCleanCloneGitHubRepo creates a guaranteed fresh checkout of a GitHub
@@ -425,8 +425,8 @@ func ShallowCloneOrOpenRepo(repoPath, repoURL string, useSSH bool) (*Repo, error
 //
 // The function returns the repository if cloning or updating of the repository
 // was successful, otherwise an error.
-func CloneOrOpenRepo(repoPath, repoURL string, useSSH bool) (*Repo, error) { //nolint: revive
-	return cloneOrOpenRepo(repoPath, repoURL, nil)
+func CloneOrOpenRepo(repoPath, repoURL string, useSSH bool, opts *git.CloneOptions) (*Repo, error) { //nolint: revive
+	return cloneOrOpenRepo(repoPath, repoURL, opts)
 }
 
 // cloneOrOpenRepo checks that the repoPath exists or creates it before running the

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -470,7 +470,7 @@ func TestFetchRemote(t *testing.T) {
 	defer originRepo.Cleanup() //nolint: errcheck
 
 	// Create a new clone of the original repo
-	testRepo, err := git.CloneOrOpenRepo("", rawRepoDir, false)
+	testRepo, err := git.CloneOrOpenRepo("", rawRepoDir, false, nil)
 	require.Nil(t, err)
 	defer testRepo.Cleanup() //nolint: errcheck
 
@@ -530,7 +530,7 @@ func TestRebase(t *testing.T) {
 	defer originRepo.Cleanup() //nolint: errcheck
 
 	// Create a new clone of the original repo
-	testRepo, err := git.CloneOrOpenRepo("", rawRepoDir, false)
+	testRepo, err := git.CloneOrOpenRepo("", rawRepoDir, false, nil)
 	require.Nil(t, err)
 	defer testRepo.Cleanup() //nolint: errcheck
 

--- a/github/fork.go
+++ b/github/fork.go
@@ -19,6 +19,7 @@ package github
 import (
 	"fmt"
 
+	gogit "github.com/go-git/go-git/v5"
 	"github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/release-sdk/git"
@@ -31,12 +32,12 @@ const (
 )
 
 // PrepareFork prepares a branch from a repo fork
-func PrepareFork(branchName, upstreamOrg, upstreamRepo, myOrg, myRepo string, useSSH bool) (repo *git.Repo, err error) {
+func PrepareFork(branchName, upstreamOrg, upstreamRepo, myOrg, myRepo string, useSSH bool, opts *gogit.CloneOptions) (repo *git.Repo, err error) {
 	// checkout the upstream repository
 	logrus.Infof("Cloning/updating repository %s/%s", upstreamOrg, upstreamRepo)
 
 	repo, err = git.CleanCloneGitHubRepo(
-		upstreamOrg, upstreamRepo, false,
+		upstreamOrg, upstreamRepo, false, opts,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("cloning %s/%s: %w", upstreamOrg, upstreamRepo, err)

--- a/test/integration/git_test.go
+++ b/test/integration/git_test.go
@@ -206,7 +206,7 @@ func newTestRepo(t *testing.T) *testRepo {
 	require.Nil(t, os.RemoveAll(cloneTempDir))
 
 	// Provide a system under test inside the test repo
-	sut, err := git.CloneOrOpenRepo("", bareTempDir, false)
+	sut, err := git.CloneOrOpenRepo("", bareTempDir, false, nil)
 	require.Nil(t, err)
 	require.Nil(t, command.NewWithWorkDir(
 		sut.Dir(), "git", "checkout", branchName,
@@ -239,7 +239,7 @@ func TestSuccessCloneOrOpen(t *testing.T) {
 	testRepo := newTestRepo(t)
 	defer testRepo.cleanup(t)
 
-	secondRepo, err := git.CloneOrOpenRepo(testRepo.sut.Dir(), testRepo.dir, false)
+	secondRepo, err := git.CloneOrOpenRepo(testRepo.sut.Dir(), testRepo.dir, false, nil)
 	require.Nil(t, err)
 
 	require.Equal(t, secondRepo.Dir(), testRepo.sut.Dir())


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

- add options to preparefork to when you need to configure special things

#### Which issue(s) this PR fixes:


None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
add options to preparefork to when you need to configure special things
```
