### PR TITLE
add option to not update the repo

### DIFF
--- a/git/git_test.go
+++ b/git/git_test.go
@@ -470,7 +470,7 @@ func TestFetchRemote(t *testing.T) {
 	defer originRepo.Cleanup() //nolint: errcheck
 
 	// Create a new clone of the original repo
-	testRepo, err := git.CloneOrOpenRepo("", rawRepoDir, false, nil)
+	testRepo, err := git.CloneOrOpenRepo("", rawRepoDir, false, true, nil)
 	require.Nil(t, err)
 	defer testRepo.Cleanup() //nolint: errcheck
 
@@ -530,7 +530,7 @@ func TestRebase(t *testing.T) {
 	defer originRepo.Cleanup() //nolint: errcheck
 
 	// Create a new clone of the original repo
-	testRepo, err := git.CloneOrOpenRepo("", rawRepoDir, false, nil)
+	testRepo, err := git.CloneOrOpenRepo("", rawRepoDir, false, true, nil)
 	require.Nil(t, err)
 	defer testRepo.Cleanup() //nolint: errcheck
 

--- a/github/fork.go
+++ b/github/fork.go
@@ -32,12 +32,12 @@ const (
 )
 
 // PrepareFork prepares a branch from a repo fork
-func PrepareFork(branchName, upstreamOrg, upstreamRepo, myOrg, myRepo string, useSSH bool, opts *gogit.CloneOptions) (repo *git.Repo, err error) {
+func PrepareFork(branchName, upstreamOrg, upstreamRepo, myOrg, myRepo string, useSSH, updateRepo bool, opts *gogit.CloneOptions) (repo *git.Repo, err error) {
 	// checkout the upstream repository
 	logrus.Infof("Cloning/updating repository %s/%s", upstreamOrg, upstreamRepo)
 
 	repo, err = git.CleanCloneGitHubRepo(
-		upstreamOrg, upstreamRepo, false, opts,
+		upstreamOrg, upstreamRepo, false, updateRepo, opts,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("cloning %s/%s: %w", upstreamOrg, upstreamRepo, err)

--- a/test/integration/git_test.go
+++ b/test/integration/git_test.go
@@ -206,7 +206,7 @@ func newTestRepo(t *testing.T) *testRepo {
 	require.Nil(t, os.RemoveAll(cloneTempDir))
 
 	// Provide a system under test inside the test repo
-	sut, err := git.CloneOrOpenRepo("", bareTempDir, false, nil)
+	sut, err := git.CloneOrOpenRepo("", bareTempDir, false, true, nil)
 	require.Nil(t, err)
 	require.Nil(t, command.NewWithWorkDir(
 		sut.Dir(), "git", "checkout", branchName,
@@ -239,7 +239,7 @@ func TestSuccessCloneOrOpen(t *testing.T) {
 	testRepo := newTestRepo(t)
 	defer testRepo.cleanup(t)
 
-	secondRepo, err := git.CloneOrOpenRepo(testRepo.sut.Dir(), testRepo.dir, false, nil)
+	secondRepo, err := git.CloneOrOpenRepo(testRepo.sut.Dir(), testRepo.dir, false, true, nil)
 	require.Nil(t, err)
 
 	require.Equal(t, secondRepo.Dir(), testRepo.sut.Dir())


### PR DESCRIPTION

#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

- add option to not update the repo

when we do a fresh close there is no need to update the repo, so adding a flag to say we dont want to update it
this function is getting bigger, i will refactor that to we pass options to reduce the signature


/assign @puerco @xmudrii 

#### Which issue(s) this PR fixes:

None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
