### PR TITLE
fix e2e tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,30 +6,27 @@ on:
       - main
   workflow_dispatch:
 
-
 jobs:
   e2e:
     runs-on: ubuntu-latest
+
     permissions:
       id-token: write
+
     steps:
       - name: Checkout code
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+
       - name: Setup golang
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: '1.21'
+          go-version: '1.22'
           check-latest: true
-      - name: Restore cache
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: go-${{ hashFiles('**/go.sum') }}
-          restore-keys: go-
+          cache: true
+
       - name: Run local registry
         run: podman run -d -p 5000:5000 registry:2
+
       - name: Build test image
         uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
         id: test-image
@@ -37,11 +34,14 @@ jobs:
           base-image: scratch
           image: test
           oci: true
+
       - name: Push test image to local registry
+        id: push
         uses: redhat-actions/push-to-registry@9986a6552bc4571882a4a67e016b17361412b4df # v2.7.1
         with:
           image: ${{ steps.test-image.outputs.image }}
           registry: localhost:5000
           tls-verify: false
+
       - name: Run e2e tests
         run: go run mage.go E2ETest

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -1,9 +1,13 @@
 ---
 dependencies:
-  - name: go
-    version: 1.21
+  - name: go (GitHub Actions)
+    version: 1.22
     refPaths:
       - path: .github/workflows/e2e.yml
         match: go-version
+
+  - name: go (go.mod)
+    version: 1.21
+    refPaths:
       - path: go.mod
         match: go

--- a/sign/sign.go
+++ b/sign/sign.go
@@ -187,6 +187,9 @@ func (s *Signer) SignImageWithOptions(options *Options, reference string) (objec
 		return nil, fmt.Errorf("sign reference: %s: %w", reference, err)
 	}
 
+	// remove the reference from the cache in case we called IsImageSigned before signing.
+	s.signedRefs.Delete(reference)
+
 	// After signing, registry consistency may not be there right
 	// away. Retry the image verification if it fails
 	// ref: https://github.com/kubernetes-sigs/promo-tools/issues/536

--- a/test/e2e/sign_test.go
+++ b/test/e2e/sign_test.go
@@ -42,7 +42,12 @@ const (
 
 func TestSignImageSuccess(t *testing.T) {
 	// Test the prerequisites
-	signer := sign.New(nil)
+	opts := sign.Default()
+	opts.IgnoreTlog = true
+	opts.CertIdentityRegexp = "https://github.com/kubernetes-sigs/release-sdk/.github/workflows/e2e.yml@.*"
+	opts.CertOidcIssuer = "https://token.actions.githubusercontent.com"
+
+	signer := sign.New(opts)
 	signed, err := signer.IsImageSigned(imageRef)
 	require.Nil(t, err)
 	require.False(t, signed)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

when calling `signer.IsImageSigned` in a image that is not signed it caches the result and if you sign the image after that it fails in the verify signature because that uses a cached info.
deleting any cache if that exists after a success signature will force the verify run the process again but this time with an image that was signed.

this test was failing for a looong time


green run: https://github.com/kubernetes-sigs/release-sdk/actions/runs/8522252234/job/23342048039


/assign @saschagrunert @puerco @xmudrii 
cc @kubernetes-sigs/release-engineering 


#### Which issue(s) this PR fixes:



None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
fix e2e tests
```
