### PR TITLE
add rate limit api check

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -156,6 +156,9 @@ type Client interface {
 	RequestPullRequestReview(
 		context.Context, string, string, int, []string, []string,
 	) (*github.PullRequest, error)
+	CheckRateLimit(
+		context.Context,
+	) (*github.RateLimits, *github.Response, error)
 }
 
 // NewIssueOptions is a struct of optional fields for new issues
@@ -566,6 +569,17 @@ func (g *githubClient) ListComments(
 	}
 
 	return comments, response, nil
+}
+
+func (g *githubClient) CheckRateLimit(
+	ctx context.Context,
+) (*github.RateLimits, *github.Response, error) {
+	rt, response, err := g.RateLimit.Get(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("fetching rate limit: %w", err)
+	}
+
+	return rt, response, nil
 }
 
 // SetClient can be used to manually set the internal GitHub client
@@ -1159,6 +1173,11 @@ func (g *GitHub) ListTags(owner, repo string) ([]*github.RepositoryTag, error) {
 		options.Page = r.NextPage
 	}
 	return tags, nil
+}
+
+// RateLimit returns the rate limits for the current client.
+func (g *GitHub) CheckRateLimit(ctx context.Context) (*github.RateLimits, *github.Response, error) {
+	return g.Client().CheckRateLimit(ctx)
 }
 
 func (g *githubClient) UpdateIssue(

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -728,3 +728,30 @@ func TestUpdateReleasePageWithOptions(t *testing.T) {
 		}
 	}
 }
+
+func TestCheckRateLimit(t *testing.T) {
+	// Given
+	sut, client := newSUT()
+
+	now := gogithub.Timestamp{time.Now().UTC()} //nolint: govet
+
+	rt := &gogithub.RateLimits{
+		Core: &gogithub.Rate{
+			Limit:     5000,
+			Remaining: 200,
+			Reset:     now,
+		},
+	}
+
+	client.CheckRateLimitReturns(rt, &gogithub.Response{}, nil)
+
+	// When
+	rt, result, err := sut.CheckRateLimit(context.Background())
+
+	// Then
+	require.Nil(t, err)
+	require.NotNil(t, result)
+	require.Equal(t, rt.Core.Limit, 5000)
+	require.Equal(t, rt.Core.Remaining, 200)
+	require.Equal(t, rt.Core.Reset, now)
+}

--- a/github/githubfakes/fake_client.go
+++ b/github/githubfakes/fake_client.go
@@ -47,6 +47,21 @@ type FakeClient struct {
 		result2 *githuba.Response
 		result3 error
 	}
+	CheckRateLimitStub        func(context.Context) (*githuba.RateLimits, *githuba.Response, error)
+	checkRateLimitMutex       sync.RWMutex
+	checkRateLimitArgsForCall []struct {
+		arg1 context.Context
+	}
+	checkRateLimitReturns struct {
+		result1 *githuba.RateLimits
+		result2 *githuba.Response
+		result3 error
+	}
+	checkRateLimitReturnsOnCall map[int]struct {
+		result1 *githuba.RateLimits
+		result2 *githuba.Response
+		result3 error
+	}
 	CreateCommentStub        func(context.Context, string, string, int, string) (*githuba.IssueComment, *githuba.Response, error)
 	createCommentMutex       sync.RWMutex
 	createCommentArgsForCall []struct {
@@ -550,6 +565,73 @@ func (fake *FakeClient) AddLabelsReturnsOnCall(i int, result1 []*githuba.Label, 
 	}
 	fake.addLabelsReturnsOnCall[i] = struct {
 		result1 []*githuba.Label
+		result2 *githuba.Response
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeClient) CheckRateLimit(arg1 context.Context) (*githuba.RateLimits, *githuba.Response, error) {
+	fake.checkRateLimitMutex.Lock()
+	ret, specificReturn := fake.checkRateLimitReturnsOnCall[len(fake.checkRateLimitArgsForCall)]
+	fake.checkRateLimitArgsForCall = append(fake.checkRateLimitArgsForCall, struct {
+		arg1 context.Context
+	}{arg1})
+	stub := fake.CheckRateLimitStub
+	fakeReturns := fake.checkRateLimitReturns
+	fake.recordInvocation("CheckRateLimit", []interface{}{arg1})
+	fake.checkRateLimitMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+}
+
+func (fake *FakeClient) CheckRateLimitCallCount() int {
+	fake.checkRateLimitMutex.RLock()
+	defer fake.checkRateLimitMutex.RUnlock()
+	return len(fake.checkRateLimitArgsForCall)
+}
+
+func (fake *FakeClient) CheckRateLimitCalls(stub func(context.Context) (*githuba.RateLimits, *githuba.Response, error)) {
+	fake.checkRateLimitMutex.Lock()
+	defer fake.checkRateLimitMutex.Unlock()
+	fake.CheckRateLimitStub = stub
+}
+
+func (fake *FakeClient) CheckRateLimitArgsForCall(i int) context.Context {
+	fake.checkRateLimitMutex.RLock()
+	defer fake.checkRateLimitMutex.RUnlock()
+	argsForCall := fake.checkRateLimitArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeClient) CheckRateLimitReturns(result1 *githuba.RateLimits, result2 *githuba.Response, result3 error) {
+	fake.checkRateLimitMutex.Lock()
+	defer fake.checkRateLimitMutex.Unlock()
+	fake.CheckRateLimitStub = nil
+	fake.checkRateLimitReturns = struct {
+		result1 *githuba.RateLimits
+		result2 *githuba.Response
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeClient) CheckRateLimitReturnsOnCall(i int, result1 *githuba.RateLimits, result2 *githuba.Response, result3 error) {
+	fake.checkRateLimitMutex.Lock()
+	defer fake.checkRateLimitMutex.Unlock()
+	fake.CheckRateLimitStub = nil
+	if fake.checkRateLimitReturnsOnCall == nil {
+		fake.checkRateLimitReturnsOnCall = make(map[int]struct {
+			result1 *githuba.RateLimits
+			result2 *githuba.Response
+			result3 error
+		})
+	}
+	fake.checkRateLimitReturnsOnCall[i] = struct {
+		result1 *githuba.RateLimits
 		result2 *githuba.Response
 		result3 error
 	}{result1, result2, result3}
@@ -2238,6 +2320,8 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.addLabelsMutex.RLock()
 	defer fake.addLabelsMutex.RUnlock()
+	fake.checkRateLimitMutex.RLock()
+	defer fake.checkRateLimitMutex.RUnlock()
 	fake.createCommentMutex.RLock()
 	defer fake.createCommentMutex.RUnlock()
 	fake.createIssueMutex.RLock()

--- a/github/record.go
+++ b/github/record.go
@@ -51,6 +51,7 @@ const (
 	gitHubAPIListMilestones             gitHubAPI = "ListMilestones"
 	gitHubAPIListIssues                 gitHubAPI = "ListIssues"
 	gitHubAPIListComments               gitHubAPI = "ListComments"
+	gitHubAPICheckRateLimit             gitHubAPI = "CheckRateLimit"
 )
 
 type apiRecord struct {
@@ -343,6 +344,19 @@ func (c *githubNotesRecordClient) ListComments(
 		return nil, nil, err
 	}
 	return comments, resp, nil
+}
+
+func (c *githubNotesRecordClient) CheckRateLimit(
+	ctx context.Context,
+) (*github.RateLimits, *github.Response, error) {
+	rt, resp, err := c.client.CheckRateLimit(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := c.recordAPICall(gitHubAPICheckRateLimit, rt, resp); err != nil {
+		return nil, nil, err
+	}
+	return rt, resp, nil
 }
 
 // recordAPICall records a single GitHub API call into a JSON file by ensuring

--- a/github/replay.go
+++ b/github/replay.go
@@ -357,3 +357,18 @@ func (c *githubNotesReplayClient) ListComments(
 	}
 	return comments, record.response(), nil
 }
+
+func (c *githubNotesReplayClient) CheckRateLimit(
+	_ context.Context,
+) (*github.RateLimits, *github.Response, error) {
+	data, err := c.readRecordedData(gitHubAPICheckRateLimit)
+	if err != nil {
+		return nil, nil, err
+	}
+	rt := &github.RateLimits{}
+	record := apiRecord{Result: rt}
+	if err := json.Unmarshal(data, &record); err != nil {
+		return nil, nil, err
+	}
+	return rt, record.response(), nil
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
- add rate limit api check
if we need to check the rate limit of a GH token and pause or do anything else

/assign @puerco @saschagrunert @xmudrii 
cc @kubernetes-sigs/release-engineering 

#### Which issue(s) this PR fixes:


None


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
add GH rate limit api check
```
