### PR TITLE
if GIT_COMMITTER_EMAIL/GIT_COMMITTER_NAME use that and not the git config info

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -1138,6 +1138,12 @@ func (r *Repo) Add(filename string) error {
 
 // GetUserName Reads the local user's name from the git configuration
 func GetUserName() (string, error) {
+	// check first if the env var is set otherwise check the git config
+	userNameFromEnv := os.Getenv("GIT_COMMITTER_NAME")
+	if userNameFromEnv != "" {
+		return userNameFromEnv, nil
+	}
+
 	// Retrieve username from git
 	userName, err := filterCommand(
 		"", "config", "--get", "user.name",
@@ -1145,17 +1151,25 @@ func GetUserName() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("reading the user name from git: %w", err)
 	}
+
 	return userName.OutputTrimNL(), nil
 }
 
 // GetUserEmail reads the user's name from git
 func GetUserEmail() (string, error) {
+	// check first if the env var is set otherwise check the git config
+	userEmailFromEnv := os.Getenv("GIT_COMMITTER_EMAIL")
+	if userEmailFromEnv != "" {
+		return userEmailFromEnv, nil
+	}
+
 	userEmail, err := filterCommand(
 		"", "config", "--get", "user.email",
 	).RunSilentSuccessOutput()
 	if err != nil {
 		return "", fmt.Errorf("reading the user's email from git: %w", err)
 	}
+
 	return userEmail.OutputTrimNL(), nil
 }
 

--- a/git/git_test.go
+++ b/git/git_test.go
@@ -102,6 +102,8 @@ func createTestRepository() (repoPath string, err error) {
 }
 
 func TestGetUserName(t *testing.T) {
+	require.Empty(t, os.Getenv("GIT_COMMITTER_NAME"))
+
 	const fakeUserName = "SIG Release Test User"
 	currentDir, err := os.Getwd()
 	require.Nil(t, err, "error reading the current directory")
@@ -123,9 +125,19 @@ func TestGetUserName(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, fakeUserName, actual)
 	require.NotEqual(t, fakeUserName, "")
+
+	envVarName := fakeUserName + " env var"
+	require.Nil(t, os.Setenv("GIT_COMMITTER_NAME", envVarName))
+	actual, err = git.GetUserName()
+	require.Nil(t, err)
+	require.Equal(t, envVarName, actual)
+	require.NotEqual(t, fakeUserName, "")
+	require.Nil(t, os.Unsetenv("GIT_COMMITTER_NAME"))
 }
 
 func TestGetUserEmail(t *testing.T) {
+	require.Empty(t, os.Getenv("GIT_COMMITTER_EMAIL"))
+
 	const fakeUserEmail = "kubernetes-test@example.com"
 	currentDir, err := os.Getwd()
 	require.Nil(t, err, "error reading the current directory")
@@ -148,6 +160,14 @@ func TestGetUserEmail(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, fakeUserEmail, actual)
 	require.NotEqual(t, fakeUserEmail, "")
+
+	envVarEmail := "kubernetes-honk@example.com"
+	require.Nil(t, os.Setenv("GIT_COMMITTER_EMAIL", envVarEmail))
+	actual, err = git.GetUserEmail()
+	require.Nil(t, err)
+	require.Equal(t, envVarEmail, actual)
+	require.NotEqual(t, envVarEmail, "")
+	require.Nil(t, os.Unsetenv("GIT_COMMITTER_EMAIL"))
 }
 
 func TestGetKubernetesRepoURLSuccess(t *testing.T) {


### PR DESCRIPTION

#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

- if GIT_COMMITTER_EMAIL/GIT_COMMITTER_NAME use that and not the git config info
related to https://github.com/kubernetes-sigs/promo-tools/issues/782


/assign @saschagrunert @puerco @xmudrii 

#### Which issue(s) this PR fixes:


#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
if GIT_COMMITTER_EMAIL/GIT_COMMITTER_NAME use that and not the git config info
```
