### PR TITLE
git: add API to retrieve `NextCommit`

### DIFF
--- a/git/git.go
+++ b/git/git.go
@@ -1490,7 +1490,7 @@ func (r *Repo) ShowLastCommit() (logData string, err error) {
 
 // LastCommitSha returns the sha of the last commit in the repository
 func (r *Repo) LastCommitSha() (string, error) {
-	shaval, err := r.runGitCmd("log", "--pretty=format:'%H'", "-n1")
+	shaval, err := r.runGitCmd("log", "--pretty=format:%H", "-n1")
 	if err != nil {
 		return "", fmt.Errorf("trying to retrieve the last commit sha: %w", err)
 	}
@@ -1630,4 +1630,18 @@ func (r *Repo) LatestReleaseBranch() (string, error) {
 
 func semverToReleaseBranch(v semver.Version) string {
 	return fmt.Sprintf("%s%d.%d", releaseBranchPrefix, v.Major, v.Minor)
+}
+
+// NextCommit determines the next child commit for the provided rev and branch.
+func (r *Repo) NextCommit(rev, branch string) (string, error) {
+	shaList, err := r.runGitCmd("log", "--reverse", "--ancestry-path", "--pretty=format:%H", fmt.Sprintf("%s...%s", rev, branch))
+	if err != nil {
+		return "", fmt.Errorf("get next commit from log: %w", err)
+	}
+	shaSplit := strings.Fields(shaList)
+	if len(shaSplit) == 0 {
+		// no child available
+		return "", nil
+	}
+	return shaSplit[0], nil
 }


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
This will be helpful for the release notes tool to skip the `--start-rev` commit, which usually points to a previous tag.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
git: added API to retrieve `NextCommit`
```
