### PR TITLE
Add e2e test for file signing

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,5 +45,11 @@ jobs:
           registry: localhost:5000
           tls-verify: false
 
+      - name: Generate test file
+        id: test-file
+        run: |
+          echo "release sign test" > ${{ runner.temp }}/test-file-${{ github.run_id }}
       - name: Run e2e tests
         run: go run mage.go E2ETest
+        with:
+          path: ${{ runner.temp }}/test-file-${{ github.run_id }}


### PR DESCRIPTION
Generates a test file from the GHA workflow that gets signed in the e2e test similar to image signing

#### What type of PR is this?

/kind cleanup

#### Which issue(s) this PR fixes:

Fix #93

#### Special notes for your reviewer:

Since the test suite uses keyless signing, I haven't fully tested the patch using the existing workflow.
There's a few options that I can think of:
- Run e2e also on PRs (preferred) 
- Mirror the repo to duplicate the workflow and testing setup

#### Does this PR introduce a user-facing change?

NONE