### PR TITLE
CreatePullRequest: add Draft flag to func args

### DIFF
--- a/github/github.go
+++ b/github/github.go
@@ -120,7 +120,7 @@ type Client interface {
 		context.Context, string, string, *github.BranchListOptions,
 	) ([]*github.Branch, *github.Response, error)
 	CreatePullRequest(
-		context.Context, string, string, string, string, string, string,
+		context.Context, string, string, string, string, string, string, bool,
 	) (*github.PullRequest, error)
 	CreateIssue(
 		context.Context, string, string, *github.IssueRequest,
@@ -430,7 +430,7 @@ func (g *githubClient) ListMilestones(
 }
 
 func (g *githubClient) CreatePullRequest(
-	ctx context.Context, owner, repo, baseBranchName, headBranchName, title, body string,
+	ctx context.Context, owner, repo, baseBranchName, headBranchName, title, body string, draft bool,
 ) (*github.PullRequest, error) {
 	newPullRequest := &github.NewPullRequest{
 		Title:               &title,
@@ -438,6 +438,7 @@ func (g *githubClient) CreatePullRequest(
 		Base:                &baseBranchName,
 		Body:                &body,
 		MaintainerCanModify: github.Bool(true),
+		Draft:               &draft,
 	}
 
 	for shouldRetry := internal.DefaultGithubErrChecker(); ; {
@@ -961,10 +962,10 @@ func (g *GitHub) CreateIssue(
 // CreatePullRequest Creates a new pull request in owner/repo:baseBranch to merge changes from headBranchName
 // which is a string containing a branch in the same repository or a user:branch pair.
 func (g *GitHub) CreatePullRequest(
-	owner, repo, baseBranchName, headBranchName, title, body string,
+	owner, repo, baseBranchName, headBranchName, title, body string, draft bool,
 ) (*github.PullRequest, error) {
 	// Use the client to create a new PR
-	pr, err := g.Client().CreatePullRequest(context.Background(), owner, repo, baseBranchName, headBranchName, title, body)
+	pr, err := g.Client().CreatePullRequest(context.Background(), owner, repo, baseBranchName, headBranchName, title, body, draft)
 	if err != nil {
 		return pr, err
 	}

--- a/github/github_test.go
+++ b/github/github_test.go
@@ -291,7 +291,7 @@ func TestCreatePullRequest(t *testing.T) {
 	client.CreatePullRequestReturns(&gogithub.PullRequest{ID: &fakeID}, nil)
 
 	// When
-	pr, err := sut.CreatePullRequest("kubernetes-fake-org", "kubernetes-fake-repo", git.DefaultBranch, "user:head-branch", "PR Title", "PR Body")
+	pr, err := sut.CreatePullRequest("kubernetes-fake-org", "kubernetes-fake-repo", git.DefaultBranch, "user:head-branch", "PR Title", "PR Body", false)
 
 	// Then
 	require.NoError(t, err)

--- a/github/githubfakes/fake_client.go
+++ b/github/githubfakes/fake_client.go
@@ -97,7 +97,7 @@ type FakeClient struct {
 		result1 *githuba.Issue
 		result2 error
 	}
-	CreatePullRequestStub        func(context.Context, string, string, string, string, string, string) (*githuba.PullRequest, error)
+	CreatePullRequestStub        func(context.Context, string, string, string, string, string, string, bool) (*githuba.PullRequest, error)
 	createPullRequestMutex       sync.RWMutex
 	createPullRequestArgsForCall []struct {
 		arg1 context.Context
@@ -107,6 +107,7 @@ type FakeClient struct {
 		arg5 string
 		arg6 string
 		arg7 string
+		arg8 bool
 	}
 	createPullRequestReturns struct {
 		result1 *githuba.PullRequest
@@ -775,7 +776,7 @@ func (fake *FakeClient) CreateIssueReturnsOnCall(i int, result1 *githuba.Issue, 
 	}{result1, result2}
 }
 
-func (fake *FakeClient) CreatePullRequest(arg1 context.Context, arg2 string, arg3 string, arg4 string, arg5 string, arg6 string, arg7 string) (*githuba.PullRequest, error) {
+func (fake *FakeClient) CreatePullRequest(arg1 context.Context, arg2 string, arg3 string, arg4 string, arg5 string, arg6 string, arg7 string, arg8 bool) (*githuba.PullRequest, error) {
 	fake.createPullRequestMutex.Lock()
 	ret, specificReturn := fake.createPullRequestReturnsOnCall[len(fake.createPullRequestArgsForCall)]
 	fake.createPullRequestArgsForCall = append(fake.createPullRequestArgsForCall, struct {
@@ -786,13 +787,14 @@ func (fake *FakeClient) CreatePullRequest(arg1 context.Context, arg2 string, arg
 		arg5 string
 		arg6 string
 		arg7 string
-	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
+		arg8 bool
+	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8})
 	stub := fake.CreatePullRequestStub
 	fakeReturns := fake.createPullRequestReturns
-	fake.recordInvocation("CreatePullRequest", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
+	fake.recordInvocation("CreatePullRequest", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8})
 	fake.createPullRequestMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -806,7 +808,7 @@ func (fake *FakeClient) CreatePullRequestCallCount() int {
 	return len(fake.createPullRequestArgsForCall)
 }
 
-func (fake *FakeClient) CreatePullRequestCalls(stub func(context.Context, string, string, string, string, string, string) (*githuba.PullRequest, error)) {
+func (fake *FakeClient) CreatePullRequestCalls(stub func(context.Context, string, string, string, string, string, string, bool) (*githuba.PullRequest, error)) {
 	fake.createPullRequestMutex.Lock()
 	defer fake.createPullRequestMutex.Unlock()
 	fake.CreatePullRequestStub = stub

--- a/github/record.go
+++ b/github/record.go
@@ -235,7 +235,7 @@ func (c *githubNotesRecordClient) ListTags(
 }
 
 func (c *githubNotesRecordClient) CreatePullRequest(
-	_ context.Context, owner, repo, baseBranchName, headBranchName, title, body string, //nolint: revive
+	_ context.Context, owner, repo, baseBranchName, headBranchName, title, body string, draft bool, //nolint: revive
 ) (*github.PullRequest, error) {
 	return &github.PullRequest{}, nil
 }

--- a/github/replay.go
+++ b/github/replay.go
@@ -231,7 +231,7 @@ func (c *githubNotesReplayClient) ListTags(
 }
 
 func (c *githubNotesReplayClient) CreatePullRequest(
-	ctx context.Context, owner, repo, baseBranchName, headBranchName, title, body string, //nolint: revive
+	ctx context.Context, owner, repo, baseBranchName, headBranchName, title, body string, draft bool, //nolint: revive
 ) (*github.PullRequest, error) {
 	return &github.PullRequest{}, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind api-change

#### What this PR does / why we need it:

Add the flag Draft to expose the same attributes as in the NewPullRequest (github.com/google/go-github/v60/github). Happy to create a new function if we feel this is gonna break many things.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add a flag draft to the function call CreatePullRequest(...)
```
